### PR TITLE
refactor: rename dimension fields to width, height, length and migrat…

### DIFF
--- a/src/data/ships.json
+++ b/src/data/ships.json
@@ -6,9 +6,9 @@
     "maxCrew": 1,
     "description": "Initially designed as Aegis’ frontline carrier ship for the military, the Avenger Stalker took a different path, ultimately having a long and storied career as the standard patrol craft of the UEE Advocacy. Utilizing its cargo hold for prisoner transport, the Avenger features a sturdy, reliable hull and the capacity for larger-than-expected engine mounts.",
     "dimensions": {
-      "w": 15,
-      "l": 20,
-      "h": 6.5
+      "width": 15,
+      "length": 20,
+      "height": 6.5
     },
     "hp": 11900,
     "hydrogenFuel": 9,
@@ -68,9 +68,9 @@
     "maxCrew": 1,
     "description": "Lacking the Prisoner Cells of the Stalker or the EMP Generator of the Warlock, the Titan’s hold is free to carry cargo. Couple that available space with the Avenger’s tried and true combat abilities and you’ve got a light cargo hauler that’s more than capable of handling itself in a fight.",
     "dimensions": {
-      "w": 15,
-      "l": 20,
-      "h": 6.5
+      "width": 15,
+      "length": 20,
+      "height": 6.5
     },
     "hp": 11900,
     "hydrogenFuel": 9,
@@ -130,9 +130,9 @@
     "maxCrew": 1,
     "description": "Created as part of the ‘Masters of Flight’ series in conjunction with the flight-sim Arena Commander, the Renegade pays tribute to famed pilot Danny Solomon for his notable work with the Advocacy to bring justice to Bremen. This Avenger Titan comes equipped with a specialized dogfighting focused loadout and a custom special edition livery honoring this iconic ship.",
     "dimensions": {
-      "w": 15,
-      "l": 20,
-      "h": 6.5
+      "width": 15,
+      "length": 20,
+      "height": 6.5
     },
     "hp": 11900,
     "hydrogenFuel": 9,
@@ -192,9 +192,9 @@
     "maxCrew": 1,
     "description": "The Avenger Warlock was built towards a single design philosophy: stop ships, don’t destroy them. Probably the closest to a non-lethal fighter, the Warlock is outfitted with a Behring REP-8 EMP Generator, capable of emitting a powerful electromagnetic wave to disable any electronics unfortunate enough to be within the blast radius.",
     "dimensions": {
-      "w": 15,
-      "l": 20,
-      "h": 6.5
+      "width": 15,
+      "length": 20,
+      "height": 6.5
     },
     "hp": 11900,
     "hydrogenFuel": 9,
@@ -261,9 +261,9 @@
     "maxCrew": 1,
     "description": "The Aegis Eclipse is a bomber designed to get in and strike before it's ever even spotted. After extensive service with the UEE, this high-tech military equipment made its civilian market debut in 2947.",
     "dimensions": {
-      "w": 24.5,
-      "l": 24.5,
-      "h": 5
+      "width": 24.5,
+      "length": 24.5,
+      "height": 5
     },
     "hp": 27044,
     "hydrogenFuel": 9,
@@ -318,9 +318,9 @@
     "maxCrew": 1,
     "description": "The Gladius is an older design which has been updated over the years to keep up with modern technology. In military circles, the Gladius is beloved for its performance and its simplicity. A fast, light fighter with a laser-focus on dogfighting, the Gladius is an ideal interceptor or escort ship.",
     "dimensions": {
-      "w": 17.5,
-      "l": 21,
-      "h": 5.5
+      "width": 17.5,
+      "length": 21,
+      "height": 5.5
     },
     "hp": 6110,
     "hydrogenFuel": 13.5,
@@ -385,9 +385,9 @@
     "maxCrew": 1,
     "description": "Created as part of the ‘Masters of Flight’ series in conjunction with the flight-sim Arena Commander, the Valiant pays tribute to famed defense pilot Condi Hillard for being the first Human on record to defeat a Vanduul in combat. This Gladius comes equipped with a specialized dogfighting focused loadout and a custom special edition livery honoring her iconic ship.",
     "dimensions": {
-      "w": 17.5,
-      "l": 21,
-      "h": 5.5
+      "width": 17.5,
+      "length": 21,
+      "height": 5.5
     },
     "hp": 6110,
     "hydrogenFuel": 13.5,
@@ -448,9 +448,9 @@
     "maxCrew": 9,
     "description": "A fast patrol ship with multiple turrets designed to combat fighters, the Hammerhead is equally suited to support larger capital ships in a fleet or act as a flagship for fighter groups.",
     "dimensions": {
-      "w": 72,
-      "l": 120,
-      "h": 16
+      "width": 72,
+      "length": 120,
+      "height": 16
     },
     "hp": 295600,
     "hydrogenFuel": 450,
@@ -498,9 +498,9 @@
     "maxCrew": 28,
     "description": "Larger than a bomber but smaller than a ship-of-the-line, frigates occupy an interesting space in the pantheon of Naval warships. While they lack the heavy armor and the capital weaponry of a cruiser, the UEE Navy prizes its frigates as they are maneuverable and can be adapted for use in a wide-range of combat scenarios.",
     "dimensions": {
-      "w": 127,
-      "l": 243,
-      "h": 57.5
+      "width": 127,
+      "length": 243,
+      "height": 57.5
     },
     "hp": 15515000,
     "hydrogenFuel": 6400,
@@ -555,9 +555,9 @@
     "maxCrew": 28,
     "description": "A mark two 'peacekeeper' variant developed for the UEE patrol services, the Idris-P strips the standard ship's ship-to-ship gun and spinal mount in favor of additional cargo capacity and superior speed.",
     "dimensions": {
-      "w": 127,
-      "l": 243,
-      "h": 57.5
+      "width": 127,
+      "length": 243,
+      "height": 57.5
     },
     "hp": 15515000,
     "hydrogenFuel": 6400,
@@ -612,9 +612,9 @@
     "maxCrew": 5,
     "description": "The Aegis Reclaimer is an industrial salvage ship. Equipped with a reinforced cargo bay, a long-range jump drive and launch pods for unmanned drones, the Reclaimer is an ideal ship for taking advantage of deep space wrecks. Tractor beams, floodlights, scanner options and docking ports round out the tools on this capable, utilitarian spacecraft.",
     "dimensions": {
-      "w": 120,
-      "l": 160,
-      "h": 55
+      "width": 120,
+      "length": 160,
+      "height": 55
     },
     "hp": 123002,
     "hydrogenFuel": 1754,
@@ -669,9 +669,9 @@
     "maxCrew": 4,
     "description": "Designed by Aegis Dynamics, the Redeemer is a powerful fighting ship capable of holding its own in combat with a powerful weapons payload. Dotted with turrets and missiles, the Redeemer also doubles as an armored landing craft capable of delivering soldiers to the frontlines.",
     "dimensions": {
-      "w": 25,
-      "l": 51,
-      "h": 14
+      "width": 25,
+      "length": 51,
+      "height": 14
     },
     "hp": 66700,
     "hydrogenFuel": 66,
@@ -726,9 +726,9 @@
     "maxCrew": 7,
     "description": "This civilian refit of the Retaliator updates the military ship's chassis with unladen space able to be fitted with various modules to suit your needs.",
     "dimensions": {
-      "w": 44,
-      "l": 70.5,
-      "h": 13.5
+      "width": 44,
+      "length": 70.5,
+      "height": 13.5
     },
     "hp": 138981,
     "hydrogenFuel": 51,
@@ -768,9 +768,9 @@
     "maxCrew": 1,
     "description": "Part of Aegis Dynamics’ Phase Two of new ship models, the Sabre was designed as a space superiority fighter for those situations where you need to leave a lighter footprint. Designed to be a rapid responder, the Sabre is more than capable of establishing battlefield dominance for any number of combat scenarios.",
     "dimensions": {
-      "w": 24.5,
-      "l": 24.5,
-      "h": 5
+      "width": 24.5,
+      "length": 24.5,
+      "height": 5
     },
     "hp": 23000,
     "hydrogenFuel": 13.5,
@@ -825,9 +825,9 @@
     "maxCrew": 1,
     "description": "Created as part of the ‘Masters of Flight’ series in conjunction with the flight-sim Arena Commander, the Comet pays tribute to famed pilot Captain Kamur Dalion for his work with Aegis to usher in a new era of combat ship design. This Sabre comes equipped with a specialized dogfighting focused loadout and a custom special edition livery honoring this iconic ship.",
     "dimensions": {
-      "w": 24.5,
-      "l": 24.5,
-      "h": 5
+      "width": 24.5,
+      "length": 24.5,
+      "height": 5
     },
     "hp": 23000,
     "hydrogenFuel": 13.5,
@@ -882,9 +882,9 @@
     "maxCrew": 1,
     "description": "Manufacturer: Aegis Dynamics\\nFocus: Medium Fighter\\n \\nWhen frontline skirmishes call for a swift and decisive offensive, the Sabre Firebird is the ideal medium fighter for any arsenal. Taking the already battle proven Sabre Raven, Aegis has designed the Firebird variant with an enhanced missile launcher capable of engaging with a wide array of threats.",
     "dimensions": {
-      "w": 24.5,
-      "l": 24.5,
-      "h": 5
+      "width": 24.5,
+      "length": 24.5,
+      "height": 5
     },
     "hp": 15500,
     "hydrogenFuel": 12,
@@ -939,9 +939,9 @@
     "maxCrew": 1,
     "description": "Manufacturer: Aegis Dynamics\\nFocus: Racing\\n \\nAfter seeing what fans of the Sabre Raven were able to accomplish with the fighter on the racetrack, the design team at Aegis Dynamics were inspired to craft an official racing variant for the agile ship. Enter the Sabre Peregrine. Streamlined and featuring additional thruster boosts, this nimble bird is ready to fly across the finish line.",
     "dimensions": {
-      "w": 24.5,
-      "l": 24.5,
-      "h": 5
+      "width": 24.5,
+      "length": 24.5,
+      "height": 5
     },
     "hp": 13550,
     "hydrogenFuel": 12,
@@ -982,9 +982,9 @@
     "maxCrew": 1,
     "description": "Aegis Dynamics have raised the bar yet again with their Raven variant, maintaining all the speed and maneuverability of its Sabre forebear, but with a lower ship signature, making it a fast, stealthy infiltrator.",
     "dimensions": {
-      "w": 24.5,
-      "l": 24.5,
-      "h": 5
+      "width": 24.5,
+      "length": 24.5,
+      "height": 5
     },
     "hp": 12500,
     "hydrogenFuel": 12,
@@ -1040,9 +1040,9 @@
     "maxCrew": 2,
     "description": "The Vanguard Harbinger is Earth's standard fighter/bomber, converting the standard Warden's escape pod into a potent bomb bay. The extended range of the Vanguard and the relatively small profile mean that it can go where carrier-based ships or larger strategic bombers don't, strike hard, and then make it back to base.",
     "dimensions": {
-      "w": 40,
-      "l": 48,
-      "h": 9.5
+      "width": 40,
+      "length": 48,
+      "height": 9.5
     },
     "hp": 42800,
     "hydrogenFuel": 39,
@@ -1112,9 +1112,9 @@
     "maxCrew": 2,
     "description": "The Vanguard Hoplite is a cross between the winning Vanguard deep space fighter and a dedicated boarding ship. Adapted from proven assault ship designs, the Hoplite is the perfect tool for inserting an armored strike team with enough firepower to get them out again.",
     "dimensions": {
-      "w": 40,
-      "l": 48,
-      "h": 9.5
+      "width": 40,
+      "length": 48,
+      "height": 9.5
     },
     "hp": 69300,
     "hydrogenFuel": 39,
@@ -1174,9 +1174,9 @@
     "maxCrew": 2,
     "description": "The Vanguard Sentinel is a ship that's designed to fight smart instead of taking enemies head on. The conversion features an AR cockpit, an external e-War pod, decoy missiles and a set of EMP charges. Vanguard Sentinels often provide necessary combat support for combined operations. A lone Sentinel is frequently paired with Harbinger bombers and Warden escorts for large attack missions.",
     "dimensions": {
-      "w": 40,
-      "l": 48,
-      "h": 9.5
+      "width": 40,
+      "length": 48,
+      "height": 9.5
     },
     "hp": 48140,
     "hydrogenFuel": 39,
@@ -1248,9 +1248,9 @@
     "maxCrew": 2,
     "description": "A hard-charging bulldog of a fighter which features extensive forward-mounted weaponry designed to tear through the shields and armor of other spacecraft. So-named because their multiple-jump range allows them to form the vanguard of any military expedition, Vanguards have seen extensive service against the Vanduul.",
     "dimensions": {
-      "w": 40,
-      "l": 48,
-      "h": 9.5
+      "width": 40,
+      "length": 48,
+      "height": 9.5
     },
     "hp": 42800,
     "hydrogenFuel": 40.5,
@@ -1314,9 +1314,9 @@
     "maxCrew": 1,
     "description": "Unmatched design, blazing top speed, and ultra-responsive maneuverability make the Arrow the most agile scrapper in its class. With a robust weapons package that provides firepower to spare, this is truly the classic light fighter, updated for the next generation of combat.",
     "dimensions": {
-      "w": 12.25,
-      "l": 17.25,
-      "h": 4.5
+      "width": 12.25,
+      "length": 17.25,
+      "height": 4.5
     },
     "hp": 8580,
     "hydrogenFuel": 7.5,
@@ -1376,9 +1376,9 @@
     "maxCrew": 1,
     "description": "Manufacturer: Anvil Aerospace\\nFocus: Vehicle Transport\\n \\nAs the battles of today continue to grow in scale and complexity, Anvil Aerospace understands the impact a single vehicle can have on the outcome. Enter the Asgard. The next generation in ground vehicle transport, the Anvil Asgard features a quick-load ramp, a sizeable hold to securely store your assault vehicle of choice, and hefty array of armaments to ensure access to even the most combat-heavy of drop sites.",
     "dimensions": {
-      "w": 38,
-      "l": 48,
-      "h": 12
+      "width": 38,
+      "length": 48,
+      "height": 12
     },
     "hp": 77000,
     "hydrogenFuel": 97.5,
@@ -1434,9 +1434,9 @@
     "maxCrew": 3,
     "description": "With its compact frame, deft maneuverability, and seating for three, the C8 Pisces snub craft, included with every Carrack, is built by Anvil Aerospace for scouting ahead or exploring environments inaccessible to its larger carrier ship.",
     "dimensions": {
-      "w": 12,
-      "l": 16,
-      "h": 8
+      "width": 12,
+      "length": 16,
+      "height": 8
     },
     "hp": 6250,
     "hydrogenFuel": 3.2,
@@ -1490,9 +1490,9 @@
     "maxCrew": 1,
     "description": "With the addition of an onboard Tier 3 Medical Bed, the C8R Pisces can treat minor injuries and keep a patient stable while transporting them to the safety of a larger ship, station, or nearby medical facility, making it an invaluable asset for short-range search and rescue.",
     "dimensions": {
-      "w": 12,
-      "l": 16,
-      "h": 8
+      "width": 12,
+      "length": 16,
+      "height": 8
     },
     "hp": 6250,
     "hydrogenFuel": 3.2,
@@ -1555,9 +1555,9 @@
     "maxCrew": 3,
     "description": "Sporting more guns and a limited-edition livery, the C8X Pisces Expedition turns the stout snub into a perfectly viable standalone exploration vessel. With its compact frame, deft maneuverability, and seating for three, the Pisces Expedition is ready to take on its own adventures.",
     "dimensions": {
-      "w": 12,
-      "l": 16,
-      "h": 8
+      "width": 12,
+      "length": 16,
+      "height": 8
     },
     "hp": 6250,
     "hydrogenFuel": 3.2,
@@ -1611,9 +1611,9 @@
     "maxCrew": 6,
     "description": "Adventure calls and Anvil Aerospace answers with the Carrack. Built to endure extreme conditions in both space and atmosphere, this self-sustaining explorer has more than earned its long-standing status as the go-to pathfinder for both military and civilian service.",
     "dimensions": {
-      "w": 126,
-      "l": 74,
-      "h": 30
+      "width": 126,
+      "length": 74,
+      "height": 30
     },
     "hp": 88000,
     "hydrogenFuel": 360,
@@ -1654,9 +1654,9 @@
     "maxCrew": 1,
     "description": "The UEE Navy's premier carrier-based fighter craft, the F7A Hornet Mk I is the front-line attack ship for military combat missions. While not outfitted for long range runs, the Hornet can take her share of hits and dish out a powerful response.",
     "dimensions": {
-      "w": 25.5,
-      "l": 28.25,
-      "h": 7.5
+      "width": 25.5,
+      "length": 28.25,
+      "height": 7.5
     },
     "hp": 16756,
     "hydrogenFuel": 14,
@@ -1726,9 +1726,9 @@
     "maxCrew": 1,
     "description": "Manufacturer: Anvil Aerospace\\nFocus: Medium Fighter\\n \\nUshering in a new age of space superiority, Anvil Aerospace has re-engineered the celebrated Hornet for the next generation of fighter combat.  Purpose built for the UEE Navy, the F7A Hornet Mk II maintains the spirit of the original while incorporating even more powerful offensive capabilities.",
     "dimensions": {
-      "w": 22,
-      "l": 22.5,
-      "h": 6.5
+      "width": 22,
+      "length": 22.5,
+      "height": 6.5
     },
     "hp": 13051,
     "hydrogenFuel": 16,
@@ -1788,9 +1788,9 @@
     "maxCrew": 1,
     "description": "To the enemy, it is a weapon never to be underestimated. To allies, it's a savior. The F7C Hornet Mk I is the same dependable and resilient multi-purpose fighter that has become the face of the UEE Navy. The F7C is the foundation to build on and meet whatever requirements you have in mind.",
     "dimensions": {
-      "w": 25.5,
-      "l": 28.25,
-      "h": 7.5
+      "width": 25.5,
+      "length": 28.25,
+      "height": 7.5
     },
     "hp": 15550,
     "hydrogenFuel": 12,
@@ -1860,9 +1860,9 @@
     "maxCrew": 1,
     "description": "Manufacturer: Anvil Aerospace\\nFocus: Medium Fighter\\n \\nStraight from the front lines to your personal hangar, the re-engineered F7C Hornet Mk II takes the latest battlefield upgrades and makes them available to private pilots across the empire. The fighter features an improved power system utilized by an overhauled weapon and missile package",
     "dimensions": {
-      "w": 22,
-      "l": 22.5,
-      "h": 6.5
+      "width": 22,
+      "length": 22.5,
+      "height": 6.5
     },
     "hp": 12751,
     "hydrogenFuel": 16,
@@ -1927,9 +1927,9 @@
     "maxCrew": 1,
     "description": "Created as part of the ‘Masters of Flight’ series in conjunction with the flight-sim Arena Commander, the Wildfire pays tribute to famed pilot Aria Reilly for her distinguished service with the legendary Squadron 42. This F7C Hornet Mk I comes equipped with her own personally selected loadout preferences and a custom special edition livery honoring her iconic ship.",
     "dimensions": {
-      "w": 25.5,
-      "l": 28.25,
-      "h": 7.5
+      "width": 25.5,
+      "length": 28.25,
+      "height": 7.5
     },
     "hp": 15550,
     "hydrogenFuel": 12,
@@ -2000,9 +2000,9 @@
     "maxCrew": 2,
     "description": "Designed for pilots whose true love is the pulse-pounding thrill of a harrowing dogfight, the limited-edition F7C-M Heartseeker Mk I is 'the one' for true combat die-hards. Loaded with top-of-the-line components and outfitted with four imposing Behring laser cannons, this fierce eradicator hones the legendary combat proficiency of the Super Hornet to give you the ultimate edge in space combat.",
     "dimensions": {
-      "w": 25.5,
-      "l": 28.25,
-      "h": 7.5
+      "width": 25.5,
+      "length": 28.25,
+      "height": 7.5
     },
     "hp": 15450,
     "hydrogenFuel": 13.5,
@@ -2067,9 +2067,9 @@
     "maxCrew": 2,
     "description": "The closest to the Military load-out as is legally possible for a Civilian model, the F7C-M Super Hornet Mk I reattaches the ball turret and offers near milspec parts under the hood. Proving that two heads are better than one, a second seat has been added to split the logistic and combat duty, making the Super Hornet a truly terrifying mark to engage.",
     "dimensions": {
-      "w": 25.5,
-      "l": 28.25,
-      "h": 7.5
+      "width": 25.5,
+      "length": 28.25,
+      "height": 7.5
     },
     "hp": 15450,
     "hydrogenFuel": 13.5,
@@ -2134,9 +2134,9 @@
     "maxCrew": 2,
     "description": "Manufacturer: Anvil Aerospace\\nFocus: Medium Fighter\\n \\nRefining their renowned military-class superiority fighter with the most up-to-date technology, Anvil Aerospace has crafted the F7C-M Super Hornet Mk II,  retaining the second seat and ball turret that made the original a truly terrifying mark to engage.",
     "dimensions": {
-      "w": 24,
-      "l": 24,
-      "h": 6.5
+      "width": 24,
+      "length": 24,
+      "height": 6.5
     },
     "hp": 15250,
     "hydrogenFuel": 16,
@@ -2205,9 +2205,9 @@
     "maxCrew": 1,
     "description": "If the Ghost is made to hide, the Tracker is made to seek. The F7C-R Hornet Tracker Mk I boasts an advanced radar suite making it ideal for deep-space explorers who require depth and accuracy in their scan packages. Local militia and larger merc units will also repurpose Trackers to act as mobile C&C ships for their squadrons.",
     "dimensions": {
-      "w": 25.5,
-      "l": 28.25,
-      "h": 7.5
+      "width": 25.5,
+      "length": 28.25,
+      "height": 7.5
     },
     "hp": 15550,
     "hydrogenFuel": 12,
@@ -2272,9 +2272,9 @@
     "maxCrew": 1,
     "description": "Manufacturer: Anvil Aerospace\\nFocus: Pathfinder\\n \\nWhen seeking the next great frontier, who better to trust than a next-generation pathfinder? The F7C-R Hornet Tracker Mk II boasts an overhauled radar suite ideal for deep-space explorers who require depth and accuracy in their scan packages.",
     "dimensions": {
-      "w": 22,
-      "l": 22.5,
-      "h": 6.5
+      "width": 22,
+      "length": 22.5,
+      "height": 6.5
     },
     "hp": 12751,
     "hydrogenFuel": 14.4,
@@ -2334,9 +2334,9 @@
     "maxCrew": 1,
     "description": "Through a combination of low-emission drives, low-draw weapons, and Void Armor technology capable of diffusing scans, the F7C-S Hornet Ghost Mk I is built for the pilot who wants to keep a low profile. The Ghost is capable of slipping past the most ardent of observers to accomplish whatever goal you need to accomplish. Don't worry, we won't ask.",
     "dimensions": {
-      "w": 25.5,
-      "l": 28.25,
-      "h": 7.5
+      "width": 25.5,
+      "length": 28.25,
+      "height": 7.5
     },
     "hp": 15350,
     "hydrogenFuel": 12,
@@ -2401,9 +2401,9 @@
     "maxCrew": 1,
     "description": "Manufacturer: Anvil Aerospace\\nFocus: Stealth Fighter\\n \\nWhen approaching the Mk II redesign of the F7C-S Hornet Ghost, the engineers at Anvil Aerospace wanted to preserve what pilots loved about the low-emission drives, low-draw weapons, and Void Armor technology of the original, but refine them to an even higher level of performance for a whole new era of stealth operations.",
     "dimensions": {
-      "w": 22,
-      "l": 22.5,
-      "h": 6.5
+      "width": 22,
+      "length": 22.5,
+      "height": 6.5
     },
     "hp": 12551,
     "hydrogenFuel": 14.4,
@@ -2463,9 +2463,9 @@
     "maxCrew": 1,
     "description": "Few vehicles employed by the proud men and women who serve in our Empire's Navy inspire the awe of the legendary F8 Lightning. A force to be reckoned with, the F8 has secured Humanity's freedom from numerous threats at home and abroad countless times. Now, that same next generation space superiority fighter is available to become a part of your personal fleet with the Anvil F8C civilian variant.",
     "dimensions": {
-      "w": 25,
-      "l": 26,
-      "h": 8
+      "width": 25,
+      "length": 26,
+      "height": 8
     },
     "hp": 40200,
     "hydrogenFuel": 37.2,
@@ -2536,9 +2536,9 @@
     "maxCrew": 2,
     "description": "The civilian model of the Gladiator appeals to those that want to explore the ‘verse with a bit of added security. Supporting a maximum of two, the Gladiator is perfectly equipped to explore and fight with or without a wingman. The Civilian model allows pilots to choose between an extra cargo hold or a bomb bay.",
     "dimensions": {
-      "w": 21,
-      "l": 22.75,
-      "h": 6
+      "width": 21,
+      "length": 22.75,
+      "height": 6
     },
     "hp": 34800,
     "hydrogenFuel": 15,
@@ -2602,9 +2602,9 @@
     "maxCrew": 1,
     "description": "A small, light fighter with an emphasis on weaponry, the Hawk boasts an impressive arsenal of lethal and non-lethal weapons, making it a perfect ship for independent bounty hunters or local security looking for a little more punch.",
     "dimensions": {
-      "w": 22,
-      "l": 17,
-      "h": 6.5
+      "width": 22,
+      "length": 17,
+      "height": 6.5
     },
     "hp": 16600,
     "hydrogenFuel": 10.5,
@@ -2664,9 +2664,9 @@
     "maxCrew": 1,
     "description": "Big things do come in small packages: the Hurricane is a fighting spacecraft that packs a deadly punch into a slight fuselage. The spacecraft compensates for its lack of creature comforts with its powerful armament: six guns capable of blasting their way through nearly anything. Hurricane pilots have yet to find an enemy shield they can't knock down.",
     "dimensions": {
-      "w": 18,
-      "l": 22,
-      "h": 6
+      "width": 18,
+      "length": 22,
+      "height": 6
     },
     "hp": 18226,
     "hydrogenFuel": 13.5,
@@ -2722,9 +2722,9 @@
     "maxCrew": 4,
     "description": "Heavy gunship equipped to take down huge targets.",
     "dimensions": {
-      "w": 38.5,
-      "l": 53,
-      "h": 14.5
+      "width": 38.5,
+      "length": 53,
+      "height": 14.5
     },
     "hp": null,
     "hydrogenFuel": null,
@@ -2770,9 +2770,9 @@
     "maxCrew": 1,
     "description": "Presenting the Anvil Aerospace U4A-3 Terrapin-class Scanning/Exploration Ship. The Terrapin was developed near the end of the 28th century to serve as the first ship in the Empire’s defensive restructuring of the Navy. The Terrapin’s watchword is protection, with extensive shield systems and armor layers designed to provide the maximum possible defense for pilot and crew. While it lacks the maneuverability of a dedicated fighter, it does maintain an advanced, hard-hitting array of weapons intended to keep the most fearsome Vanduul raider at bay.",
     "dimensions": {
-      "w": 16.5,
-      "l": 20,
-      "h": 7.5
+      "width": 16.5,
+      "length": 20,
+      "height": 7.5
     },
     "hp": 168201,
     "hydrogenFuel": 104.5,
@@ -2820,9 +2820,9 @@
     "maxCrew": 1,
     "description": "Maintaining the famed toughness of the original Terrapin, Anvil designers have crafted an optimal vehicle for rescue operations with the Terrapin Medic. Featuring a tier 2 medical bed, the Terrapin Medic can extract injured parties from even the most hazardous situations thanks to its powerful armor and shielding.\\n",
     "dimensions": {
-      "w": 16.5,
-      "l": 20,
-      "h": 7.5
+      "width": 16.5,
+      "length": 20,
+      "height": 7.5
     },
     "hp": 168201,
     "hydrogenFuel": 104.5,
@@ -2878,9 +2878,9 @@
     "maxCrew": 5,
     "description": "The Valkyrie ups the ante on troop transport. Designed to carry up to twenty soldiers, as well as vehicles, to the most hostile locations, this conflict-ready mil-spec craft is a formidable force, both offensively and defensively. Built with military and private defense contractors in mind, the Valkyrie is one of the most efficient and effective personnel transports in its class.",
     "dimensions": {
-      "w": 38,
-      "l": 48,
-      "h": 12
+      "width": 38,
+      "length": 48,
+      "height": 12
     },
     "hp": 90053,
     "hydrogenFuel": 94.5,
@@ -2927,9 +2927,9 @@
     "maxCrew": 1,
     "description": "The Xi'an Aopoa corporation manufactures an export model of the Qhire Khartu, the Khartu-al, for sale to human civilians as a dedicated scout/explorer. The export model features the same Xi'an maneuvering rig, but control surfaces modified for Human use and a more limited armament.",
     "dimensions": {
-      "w": 13.5,
-      "l": 32,
-      "h": 8.75
+      "width": 13.5,
+      "length": 32,
+      "height": 8.75
     },
     "hp": 14100,
     "hydrogenFuel": 26,
@@ -2977,9 +2977,9 @@
     "maxCrew": 1,
     "description": "Hit the skids with the 2947 Nox. This speedy and maneuverable open-canopy racer from Aopoa is capable of zipping along planet surfaces or deep space. Available for the first time in Human space, the Nox has been specifically redesigned for Human pilots and is ready to race.",
     "dimensions": {
-      "w": 1.32,
-      "l": 1.45,
-      "h": 5.15
+      "width": 1.32,
+      "length": 1.45,
+      "height": 5.15
     },
     "hp": 2231,
     "hydrogenFuel": 1.5,
@@ -3027,9 +3027,9 @@
     "maxCrew": 1,
     "description": "Harnessing the power of next-generation Xi'an flight systems, upgraded dual-vector thrusters, and a daunting weapons package, Aopoa has crafted a fighter that retains the nimble dexterity and tight handling the brand is known for.",
     "dimensions": {
-      "w": 23,
-      "l": 24,
-      "h": 23
+      "width": 23,
+      "length": 24,
+      "height": 23
     },
     "hp": 11475.880000000001,
     "hydrogenFuel": 14.7,
@@ -3085,9 +3085,9 @@
     "maxCrew": 4,
     "description": "Argo’s iconic multi-operator laser extractor, more commonly referred to as the MOLE, lets you work faster and more effectively than ever before, thanks to its patented trilateral mining system. Three independently controlled articulated extraction stations allow for maximum power and near-limitless versatility. The MOLE lives by the adage \"many hands make for light work\".",
     "dimensions": {
-      "w": 26,
-      "l": 45,
-      "h": 15
+      "width": 26,
+      "length": 45,
+      "height": 15
     },
     "hp": 80375,
     "hydrogenFuel": 200,
@@ -3141,9 +3141,9 @@
     "maxCrew": 1,
     "description": "The Argo Astronautics MPUV Cargo is a dedicated merchant transfer ship. A ubiquitous intergalactic stevedore, vast numbers of MPUV Cargos are responsible for loading and unloading goods onto ships that can't otherwise land on planets or drydocks, such as the Hull D and the Orion. Some hauler captains choose to own and operate their own Argo, while others prefer to contract with the local Argo owners found at many of the busier ports.",
     "dimensions": {
-      "w": 9,
-      "l": 10.5,
-      "h": 5
+      "width": 9,
+      "length": 10.5,
+      "height": 5
     },
     "hp": 5920,
     "hydrogenFuel": 3,
@@ -3184,9 +3184,9 @@
     "maxCrew": 1,
     "description": "The Argo Astronautics MPUV-1P (commonly ‘Argo Personnel’). This version of the Argo is geared towards a simple but incredibly important responsibility: moving grounds of people from place to place. The UEE Navy uses MPUV-1Ps extensively, and any new recruit can likely recall those terrifying moments in which such a ship carried them to their first space assignment. In civilian hands, Argo Personnel ships are adapted for everything from standard taxi services to use as makeshift combat dropships. The Argo MPUV-1P is capable of carrying up to eight humans and their equipment.",
     "dimensions": {
-      "w": 9,
-      "l": 10.5,
-      "h": 5
+      "width": 9,
+      "length": 10.5,
+      "height": 5
     },
     "hp": 5920,
     "hydrogenFuel": 3,
@@ -3227,9 +3227,9 @@
     "maxCrew": 1,
     "description": "The Argo Astronautics MPUV-1T is outfitted with a tractor beam to allow it to handily move cargo containers on and off larger hauling vessels.  Its smaller size and maneuverability make it an ideal support vehicle at landing zones and space stations.",
     "dimensions": {
-      "w": 9,
-      "l": 10.5,
-      "h": 5.5
+      "width": 9,
+      "length": 10.5,
+      "height": 5.5
     },
     "hp": 6380,
     "hydrogenFuel": 3,
@@ -3282,9 +3282,9 @@
     "maxCrew": 2,
     "description": "The Argo RAFT features a hefty 96 SCU cargo hold, and is capable of carrying up to three standardized 32 SCU cargo containers. Perfect for entry-level haulers and old pros alike, the RAFT is an ideal solution for reliable local freight transport.",
     "dimensions": {
-      "w": 23,
-      "l": 39.5,
-      "h": 12
+      "width": 23,
+      "length": 39.5,
+      "height": 12
     },
     "hp": 57468.7,
     "hydrogenFuel": 225,
@@ -3339,9 +3339,9 @@
     "maxCrew": 1,
     "description": "When it comes to getting the job done, Argo doesn’t mess around. From simple freight and cargo towing to harrowing search-and-rescue operations, the SRV handles whatever you can throw at it. The bespoke tractor system utilizes an innovative plate and arm combination, allowing for effortless solo use as well as precision team towing for bigger jobs. Your crew and passengers stay safe too thanks to durable shields and heavy-duty armor that keep the cockpit and components secure when the situation gets hairy.",
     "dimensions": {
-      "w": 21.5,
-      "l": 31.5,
-      "h": 9.5
+      "width": 21.5,
+      "length": 31.5,
+      "height": 9.5
     },
     "hp": 34500,
     "hydrogenFuel": 28.5,
@@ -3389,9 +3389,9 @@
     "maxCrew": 1,
     "description": "Meet the Banu Defender, a multi-crew fighter whose patchwork design highlights technology from a variety of species. Featuring modest accommodations for its crew and easy access to components, the Defender gets its name from the role it serves: the first line of defense against enemy attacks. That's why the Defender makes the ideal companion to the Merchantman: one to do the heavy hauling and the other to perform the deadly dogfighting.",
     "dimensions": {
-      "w": 24.5,
-      "l": 24.5,
-      "h": 5
+      "width": 24.5,
+      "length": 24.5,
+      "height": 5
     },
     "hp": 13800,
     "hydrogenFuel": 43,
@@ -3446,9 +3446,9 @@
     "maxCrew": 1,
     "description": "Designed as a companion ground vehicle for the Nomad, the HoverQuad's sleek angular frame utilizes four gravlev pads for maximum maneuverability, making it the perfect transport across all kinds of surfaces.",
     "dimensions": {
-      "w": 1.32,
-      "l": 1.45,
-      "h": 5.15
+      "width": 1.32,
+      "length": 1.45,
+      "height": 5.15
     },
     "hp": 3300,
     "hydrogenFuel": 1.6,
@@ -3489,9 +3489,9 @@
     "maxCrew": 1,
     "description": "Inspired by Consolidated Outland CEO Silas Koerner’s cutting edge vision, the Mustang Alpha is a sleek, stylish spacecraft that uses ultralight alloys to push power ratios to the limits, albeit sometimes unsafely. And now, with the optional Cargo Carrier, you can have the Alpha’s advantages without sacrificing carrying capacity.",
     "dimensions": {
-      "w": 18,
-      "l": 21.5,
-      "h": 9
+      "width": 18,
+      "length": 21.5,
+      "height": 9
     },
     "hp": 10080,
     "hydrogenFuel": 6,
@@ -3544,9 +3544,9 @@
     "maxCrew": 1,
     "description": "The Mustang Beta, with its unprecedented range, is made for long duration flights. The factory standard Tarsus Leaper Jump Engine enables the Beta to travel to the galaxy’s farthest systems with ease, while the ship’s unique Com4T living quarters will make the journey feel like you never left home.",
     "dimensions": {
-      "w": 18,
-      "l": 21.5,
-      "h": 9
+      "width": 18,
+      "length": 21.5,
+      "height": 9
     },
     "hp": 10080,
     "hydrogenFuel": 8,
@@ -3599,9 +3599,9 @@
     "maxCrew": 1,
     "description": "While it may not be able to go toe to toe with some of the military specific ships, by reinforcing the Mustang’s already strong hull construction with Consolidated Outland’s own line of Cavalry Class Mass Reduction Armor, the Delta has a reduced cross-sectional signature that evens the playing field.",
     "dimensions": {
-      "w": 18,
-      "l": 21.5,
-      "h": 9
+      "width": 18,
+      "length": 21.5,
+      "height": 9
     },
     "hp": 10080,
     "hydrogenFuel": 7.5,
@@ -3654,9 +3654,9 @@
     "maxCrew": 1,
     "description": "Consolidated Outland’s design and engineering teams have managed to tweak and refine the Mustang into an admirable racer. The end result, the Mustang Gamma, has smooth acceleration, and power on demand thanks to an innovative package featuring three powerful Magma Jet engines for maximum thrust.",
     "dimensions": {
-      "w": 18,
-      "l": 21.5,
-      "h": 9
+      "width": 18,
+      "length": 21.5,
+      "height": 9
     },
     "hp": 8580,
     "hydrogenFuel": 6,
@@ -3704,9 +3704,9 @@
     "maxCrew": 1,
     "description": "Consolidated Outland teamed up with custom tuning company Accelerated Mass Design to create a limited edition racer that features a ramped up fuel intake for faster recycling of the ship’s already impressive boost system. To cap off the collaboration, AMD enlisted resident underground artist Sektor8 to design the dynamic paint job.",
     "dimensions": {
-      "w": 18,
-      "l": 21.5,
-      "h": 9
+      "width": 18,
+      "length": 21.5,
+      "height": 9
     },
     "hp": 8580,
     "hydrogenFuel": 6,
@@ -3754,9 +3754,9 @@
     "maxCrew": 1,
     "description": "With the versatility of a medium-sized multi-purpose freighter packed into a stylish, compact frame, the Consolidated Outland Nomad is the model of self-sufficiency, the spirit of the open sky, and the perfect solution for anyone yearning to start a brand-new adventure.",
     "dimensions": {
-      "w": 27,
-      "l": 19,
-      "h": 10
+      "width": 27,
+      "length": 19,
+      "height": 10
     },
     "hp": 9800,
     "hydrogenFuel": 32.8,
@@ -3818,9 +3818,9 @@
     "maxCrew": 2,
     "description": "Crusader Industries brings its usual commitment to excellence directly to the civilian market with the A1 Spirit, a mid-size multi-purpose starship equipped as a light bomber but packing enough versatility to tackle multiple roles and unpredictable jobs.",
     "dimensions": {
-      "w": 47.5,
-      "l": 44,
-      "h": 10
+      "width": 47.5,
+      "length": 44,
+      "height": 10
     },
     "hp": 67600,
     "hydrogenFuel": 45,
@@ -3881,9 +3881,9 @@
     "maxCrew": 6,
     "description": "The A2 gunship has been used to devastating effect in airborne assaults, search and rescue operations, and landing initiatives. With more than double the firepower of the M2, and a custom bomb bay capable of delivering a staggering payload, the A2 caters to anyone hauling massive amounts of cargo through potentially unfriendly skies.",
     "dimensions": {
-      "w": 94,
-      "l": 70,
-      "h": 23
+      "width": 94,
+      "length": 70,
+      "height": 23
     },
     "hp": 112530,
     "hydrogenFuel": 132,
@@ -3937,9 +3937,9 @@
     "maxCrew": 1,
     "description": "Whether heading up a crew or hunting big ships solo, the Ares Inferno is a force to be reckoned with. This ballistic Gatling-equipped variant tears through gunship armor and turns smaller fighters to dust in seconds.",
     "dimensions": {
-      "w": 30,
-      "l": 27,
-      "h": 6
+      "width": 30,
+      "length": 27,
+      "height": 6
     },
     "hp": 38600,
     "hydrogenFuel": 45,
@@ -3994,9 +3994,9 @@
     "maxCrew": 1,
     "description": "Spark fear in the corridors of the most formidable gunships and frigates with the Ares Ion. This laser-equipped variant delivers extremely powerful shots to quickly disable the shields of even the biggest enemy vessels.",
     "dimensions": {
-      "w": 30,
-      "l": 27,
-      "h": 6
+      "width": 30,
+      "length": 27,
+      "height": 6
     },
     "hp": 38600,
     "hydrogenFuel": 45,
@@ -4051,9 +4051,9 @@
     "maxCrew": 2,
     "description": "Crusader Industries brings its usual commitment to excellence directly to the civilian market with the C1 Spirit, a mid-size multi-purpose starship built for cargo transport and delivery but packing enough versatility to tackle multiple roles and unpredictable jobs.",
     "dimensions": {
-      "w": 47.5,
-      "l": 44,
-      "h": 10
+      "width": 47.5,
+      "length": 44,
+      "height": 10
     },
     "hp": 67600,
     "hydrogenFuel": 45,
@@ -4115,9 +4115,9 @@
     "maxCrew": 2,
     "description": "Utilizing the patented Hercules military-grade spaceframe and expanding cargo capacity, while sacrificing barely any firepower, the C2 has taken the private sector by storm. It has become the industry standard for racing teams, ship dealers and manufacturers, construction orgs, mining corporations, and even large-scale touring entertainment outfits.",
     "dimensions": {
-      "w": 94,
-      "l": 70,
-      "h": 23
+      "width": 94,
+      "length": 70,
+      "height": 23
     },
     "hp": 81400,
     "hydrogenFuel": 132,
@@ -4165,9 +4165,9 @@
     "maxCrew": 1,
     "description": "For those eager to meet their future head on, the renowned ship engineers at Crusader Industries proudly present the Intrepid. A bold ship ready to tackle any number of jobs and conquer numerous challenges, the Intrepid features efficient cargo space and comfortable living quarters to make the most of your solo journey across the stars.",
     "dimensions": {
-      "w": 20.18,
-      "l": 23.07,
-      "h": 6.13
+      "width": 20.18,
+      "length": 23.07,
+      "height": 6.13
     },
     "hp": 15350,
     "hydrogenFuel": 26,
@@ -4223,9 +4223,9 @@
     "maxCrew": 3,
     "description": "The M2 Hercules is the UEE's premier tactical starlifter. The large-scale transport's potent combination of capacity, maneuverability, durability, and robust weapons package assures your cargo and crew get to where they’re going in one piece.",
     "dimensions": {
-      "w": 94,
-      "l": 70,
-      "h": 23
+      "width": 94,
+      "length": 70,
+      "height": 23
     },
     "hp": 101820,
     "hydrogenFuel": 132,
@@ -4273,9 +4273,9 @@
     "maxCrew": 3,
     "description": "If you need it there fast and unscathed, the Mercury checks all the boxes expected of a dependable courier vessel and then some. Built with the same engineering and design principles that have made Crusader Industries the go-to manufacturer for galactic transport on any scale, the Mercury Star Runner will let you stay ahead of schedule, trouble, and the competition.",
     "dimensions": {
-      "w": 55,
-      "l": 51,
-      "h": 19
+      "width": 55,
+      "length": 51,
+      "height": 19
     },
     "hp": 41400,
     "hydrogenFuel": 100,
@@ -4334,9 +4334,9 @@
     "maxCrew": 1,
     "description": "The Buccaneer has been designed from the ground up to fly and fight the way you live. No leather interiors or hyperpillows here: the Bucc is a scrapper designed to maneuver and fight above its weight class. This rough-and-tumble frontier fighter can be maintained in the worst of conditions in order to keep real, working space crews alive.",
     "dimensions": {
-      "w": 16.75,
-      "l": 15.25,
-      "h": 5.5
+      "width": 16.75,
+      "length": 15.25,
+      "height": 5.5
     },
     "hp": 9480,
     "hydrogenFuel": 7.5,
@@ -4402,9 +4402,9 @@
     "maxCrew": 4,
     "description": "First introduced in 2871, Drake Interplanetary's Caterpillar has long proven to be a reliable, cost-effective multi-role vessel, capable of being outfitted for everything from mercantile operations to combat support. Long hailed as a hard-fought alternative to the ubiquitous Hull series, the Caterpillar is a freighter that doesn't skimp on weaponry or customization.",
     "dimensions": {
-      "w": 39.5,
-      "l": 13.4,
-      "h": 111.5
+      "width": 39.5,
+      "length": 13.4,
+      "height": 111.5
     },
     "hp": 92700,
     "hydrogenFuel": 250.5,
@@ -4459,9 +4459,9 @@
     "maxCrew": 4,
     "description": "Heed the call of uncharted space and harness the spirit of exploration with the Drake Corsair. Utilizing a unique asymmetrical hull design, this versatile explorer can go wherever the winds of adventure may steer you.",
     "dimensions": {
-      "w": 30,
-      "l": 53,
-      "h": 25
+      "width": 30,
+      "length": 53,
+      "height": 25
     },
     "hp": 91000,
     "hydrogenFuel": 116,
@@ -4521,9 +4521,9 @@
     "maxCrew": 3,
     "description": "Drake Interplanetary claims that the Cutlass Black is a low-cost, easy-to-maintain solution for local in-system militia units. The larger-than-average cargo hold, RIO seat and dedicated tractor mount are, the company literature insists, for facilitating search and rescue operations.",
     "dimensions": {
-      "w": 26.5,
-      "l": 37.5,
-      "h": 11.5
+      "width": 26.5,
+      "length": 37.5,
+      "height": 11.5
     },
     "hp": 29760,
     "hydrogenFuel": 36,
@@ -4595,9 +4595,9 @@
     "maxCrew": 3,
     "description": "Sleek, mean, and royal. The Cutlass Blue adds missiles, a more aggressive engine, and Durasteel holding cells in the cargo bay to the standard model. The Cutlass Blue is the outworld militia standard ship of choice for patrols.",
     "dimensions": {
-      "w": 26.5,
-      "l": 37.5,
-      "h": 11.5
+      "width": 26.5,
+      "length": 37.5,
+      "height": 11.5
     },
     "hp": 35770,
     "hydrogenFuel": 36,
@@ -4664,9 +4664,9 @@
     "maxCrew": 3,
     "description": "The Cutlass Red converts the standard cargo hold to a well-equiped medical facility including an Autodoc. This starbound ambulance features the Nav-E7 Echo Transponder, a long range scanner, and a Secure Plus Docking Collar, making it ideal for search and rescue. This model also features a unique Red Crossbones skin.",
     "dimensions": {
-      "w": 26.5,
-      "l": 37.5,
-      "h": 11.5
+      "width": 26.5,
+      "length": 37.5,
+      "height": 11.5
     },
     "hp": 34520,
     "hydrogenFuel": 36,
@@ -4726,9 +4726,9 @@
     "maxCrew": 3,
     "description": "With the Cutlass Steel, Drake Interplanetary has once again reinvented their classic design to create a next generation combat transport ship through the addition of dedicated jump seats and an expanded arsenal. It’s a dangerous ‘verse out there, and the Cutlass Steel is ready to cut a path through whatever stands in the way of you and your dedicated crew.",
     "dimensions": {
-      "w": 26.5,
-      "l": 37.5,
-      "h": 11.5
+      "width": 26.5,
+      "length": 37.5,
+      "height": 11.5
     },
     "hp": 32660,
     "hydrogenFuel": 36,
@@ -4792,9 +4792,9 @@
     "maxCrew": 1,
     "description": "Designed for hard-working folks of all stripes, the Cutter packs 4 SCU of cargo room and plenty of wallop into a rough and tumble, compact frame. It's a ship that truly embodies the spirit of Drake: that no matter who you are or what you do, you can reach the stars.",
     "dimensions": {
-      "w": 16,
-      "l": 20,
-      "h": 6
+      "width": 16,
+      "length": 20,
+      "height": 6
     },
     "hp": 17100,
     "hydrogenFuel": 12,
@@ -4849,9 +4849,9 @@
     "maxCrew": 1,
     "description": "The brass at Drake heard what you had to say, and their answer was the Cutter Rambler. Building upon the original, the Rambler preserves a full 2 SCU of cargo room while adding in requested creature comforts and enough personal storage to make even the longest journey go by in a flash.",
     "dimensions": {
-      "w": 16,
-      "l": 20,
-      "h": 6
+      "width": 16,
+      "length": 20,
+      "height": 6
     },
     "hp": 17100,
     "hydrogenFuel": 24,
@@ -4906,9 +4906,9 @@
     "maxCrew": 1,
     "description": "Pairing down the rough and tumble, compact frame of the Cutter to the bare essentials, Drake took an already impressive ship and transformed it into the ideal scouting vessel. Featuring improved radar and scanning capabilities paired with more power and cooling, the Cutter Scout is ready to fly ahead of the pack.",
     "dimensions": {
-      "w": 16,
-      "l": 20,
-      "h": 6
+      "width": 16,
+      "length": 20,
+      "height": 6
     },
     "hp": 17500,
     "hydrogenFuel": 12,
@@ -4963,9 +4963,9 @@
     "maxCrew": 1,
     "description": "The Drake Dragonfly is the perfect snub ship for anyone looking to live on the edge. With nothing separating the pilot from the dangers of space, the Dragonfly is as much an adventure as a ship! Dual-mode conversion allows the Dragonfly to operate on the ground or in space, and a rear-facing second seat means you can even take a passenger!",
     "dimensions": {
-      "w": 2.5,
-      "l": 7,
-      "h": 2
+      "width": 2.5,
+      "length": 7,
+      "height": 2
     },
     "hp": 1570,
     "hydrogenFuel": 1.5,
@@ -5006,9 +5006,9 @@
     "maxCrew": 1,
     "description": "With the Golem, Drake designed the ideal ship for those interested in starting a mining career. The ship features a bespoke mining laser and the capacity to carry 32 SCU of valuable resources. In classic Drake fashion, the Golem is a purpose-built ship that prioritizes function over frills.",
     "dimensions": {
-      "w": 15.5,
-      "l": 7,
-      "h": 5
+      "width": 15.5,
+      "length": 7,
+      "height": 5
     },
     "hp": 17300,
     "hydrogenFuel": 24,
@@ -5070,9 +5070,9 @@
     "maxCrew": 1,
     "description": "The Drake Herald is a small, armored ship designed to safely get information from Point A to Point B. Featuring a powerful central engine (for high speed transit and generating the power needed for effective data encryption/containment), advanced encryption software and an armored computer core, the Herald is unique among personal spacecraft in that it is designed to be easily ‘cleaned’ when in danger of capture.",
     "dimensions": {
-      "w": 12.5,
-      "l": 24.75,
-      "h": 9
+      "width": 12.5,
+      "length": 24.75,
+      "height": 9
     },
     "hp": 6500,
     "hydrogenFuel": 10.5,
@@ -5132,9 +5132,9 @@
     "maxCrew": 1,
     "description": "Answer to no one, cut out the middle man, and throw caution to the wind. Rip wrecks like a pro and carve out your own place in the great big empty behind the stick of this rough, rugged salvage machine from Drake Interplanetary.",
     "dimensions": {
-      "w": 16,
-      "l": 34,
-      "h": 9
+      "width": 16,
+      "length": 34,
+      "height": 9
     },
     "hp": 43700,
     "hydrogenFuel": 36,
@@ -5189,9 +5189,9 @@
     "maxCrew": 1,
     "description": "These light fighters, designation 'Blade', are often used by Vanduul as scouts and first wave assault crafts. They have also served well as skirmisher units due to their speed allowing them to chase down any ships attempting to flee the area. For some decades, United Empire of Earth aggressor squadrons have operated replica Blade fighters produced under exclusive contract by Esperia, Inc.",
     "dimensions": {
-      "w": 16.5,
-      "l": 20.5,
-      "h": 5.5
+      "width": 16.5,
+      "length": 20.5,
+      "height": 5.5
     },
     "hp": 7950,
     "hydrogenFuel": 8,
@@ -5251,9 +5251,9 @@
     "maxCrew": 1,
     "description": "The Glaive is a symmetrical version of the Scythe. Generally flown by Vanduul with more combat experience, they are better armed and have two huge blades/wings as opposed to one on the standard Scythe.",
     "dimensions": {
-      "w": 24,
-      "l": 33,
-      "h": 9
+      "width": 24,
+      "length": 33,
+      "height": 9
     },
     "hp": 10962,
     "hydrogenFuel": 9,
@@ -5313,9 +5313,9 @@
     "maxCrew": 1,
     "description": "Named after the UPE military designation, the Prowler is a modernized version of the infamous Tevarin boarding craft from the First Tevarin War. The Prowler’s effectiveness as a rapid personnel deployment vehicle was mainly due to its silence. With the Prowler, you will find the perfect fusion of two cultures: the elegance and effectiveness of the Tevarin war machine combined with the reliability of modern UEE technology.",
     "dimensions": {
-      "w": 32,
-      "l": 34,
-      "h": 15
+      "width": 32,
+      "length": 34,
+      "height": 15
     },
     "hp": 76900,
     "hydrogenFuel": 39,
@@ -5364,9 +5364,9 @@
     "maxCrew": 5,
     "description": "While no known Tevarin-made examples of this historical ship exist, historians at Esperia studied contemporary UPE military field reports to reconstruct this modified Prowler. Used by the Tevarin military to deliver urgently needed supplies to the frontlines, the Prowler Utility pairs a tractor beam with a fully accessible hold, alongside the warship’s still significant armaments, to make the transfer of cargo in battlefield conditions a precision operation.",
     "dimensions": {
-      "w": 32,
-      "l": 34,
-      "h": 15
+      "width": 32,
+      "length": 34,
+      "height": 15
     },
     "hp": 69300,
     "hydrogenFuel": 43,
@@ -5420,9 +5420,9 @@
     "maxCrew": 1,
     "description": "The Talon represents Esperia's continuing effort to preserve historically significant Tevarin ship designs. A maneuverable single-seat combat ship with light armor but powerful, directional \"Phalanx\" shields, the Talon is made to strike first and strike hard before using the shields to cover its escape.",
     "dimensions": {
-      "w": 15,
-      "l": 24,
-      "h": 8
+      "width": 15,
+      "length": 24,
+      "height": 8
     },
     "hp": 24930,
     "hydrogenFuel": 8,
@@ -5477,9 +5477,9 @@
     "maxCrew": 1,
     "description": "The Talon represents Esperia's continuing effort to preserve historically significant Tevarin ship designs. A maneuverable single-seat combat ship with light armor but powerful, directional \"Phalanx\" shields, the Talon is made to strike first and strike hard before using the shields to cover its escape. The infamous Shrike variant model is armed with additional internal missile racks.",
     "dimensions": {
-      "w": 15,
-      "l": 24,
-      "h": 8
+      "width": 15,
+      "length": 24,
+      "height": 8
     },
     "hp": 24930,
     "hydrogenFuel": 8,
@@ -5534,9 +5534,9 @@
     "maxCrew": 1,
     "description": "The Syulen cargo vessel has been artfully crafted by the renowned House Gatac to be well suited for both Human and Xi’an pilots. With a refined agile frame, the Syulen lends itself to ferrying important deliveries across the universe, or as the ideal ship for those making their transport career debut.",
     "dimensions": {
-      "w": 28,
-      "l": 25,
-      "h": 16
+      "width": 28,
+      "length": 25,
+      "height": 16
     },
     "hp": 11740,
     "hydrogenFuel": 40,
@@ -5589,17 +5589,17 @@
     "career": "Combat",
     "cargo": 0,
     "maxCrew": 1,
-    "description": "Meet a ship almost 400 years in the making, and well worth the wait. Kruger Intergalactic is excited to present their first independently manufactured ship, the L-21 Wolf. Combining speed, style, and an impeccably precise design, the L-21 Wolf is not only a showcase for Kruger but is battle-ready to hunt alone or in packs with a powerful array of armaments, including two bespoke S4 ballistic gatlings.",
+    "description": "Meet a ship almost 400 years in the making, and well worth the wait. Kruger Intergalactic is excited to present their first independently manufactured ship, the length-21 Wolf. Combining speed, style, and an impeccably precise design, the length-21 Wolf is not only a showcase for Kruger but is battle-ready to hunt alone or in packs with a powerful array of armaments, including two bespoke S4 ballistic gatlings.",
     "dimensions": {
-      "w": 5.25,
-      "l": 12,
-      "h": 3
+      "width": 5.25,
+      "length": 12,
+      "height": 3
     },
     "hp": 8500,
     "hydrogenFuel": 9,
     "manufacturer": "KRIG",
     "mass": 23350,
-    "name": "L-21 Wolf",
+    "name": "length-21 Wolf",
     "qtFuel": 0.9,
     "role": "Light Fighter",
     "size": 2,
@@ -5648,9 +5648,9 @@
     "maxCrew": 1,
     "description": "Designed in conjunction with RSI, this elegant short-range snub fighter represents the first ship produced under the Kruger Intergalactic brand. Utilizing centuries of manufacturing expertise, the compact precision of the Kruger hull blends perfectly with the trusted RSI thrusters to grant the Merlin exceptional handling and maneuverability while ensuring that it is capable of fulfilling a variety of roles from combat to scouting to scanning.",
     "dimensions": {
-      "w": 5.25,
-      "l": 12,
-      "h": 3
+      "width": 5.25,
+      "length": 12,
+      "height": 3
     },
     "hp": 2480,
     "hydrogenFuel": 7,
@@ -5703,9 +5703,9 @@
     "maxCrew": 1,
     "description": "Whether for added security, exploring a system or simply the joy of flying, the Kruger Intergalactic’s P-72 Archimedes snub craft was designed to deliver exceptional handling and nimble acceleration in a sleek and stylish package.",
     "dimensions": {
-      "w": 5.25,
-      "l": 12,
-      "h": 3
+      "width": 5.25,
+      "length": 12,
+      "height": 3
     },
     "hp": 2080,
     "hydrogenFuel": 7,
@@ -5753,9 +5753,9 @@
     "maxCrew": 1,
     "description": "Featuring best-in-class maneuverability and fully integrated, cutting-edge Xi’an tech, the next-generation Fury snub fighter from Mirai uses its four halo-mounted size 2 laser repeaters to redefine short-range space combat.",
     "dimensions": {
-      "w": 5.4,
-      "l": 7,
-      "h": 3
+      "width": 5.4,
+      "length": 7,
+      "height": 3
     },
     "hp": 6566,
     "hydrogenFuel": 2.75,
@@ -5810,9 +5810,9 @@
     "maxCrew": 1,
     "description": "Featuring best-in-class maneuverability and fully integrated, cutting-edge Xi’an tech, the next-generation Fury LX racing ship from Mirai switches out the lithe ship’s offensive capabilities to make room for additional maneuvering thrusters perfect for getting across the finish line.",
     "dimensions": {
-      "w": 5.4,
-      "l": 7,
-      "h": 3
+      "width": 5.4,
+      "length": 7,
+      "height": 3
     },
     "hp": 3137,
     "hydrogenFuel": 2.75,
@@ -5853,9 +5853,9 @@
     "maxCrew": 1,
     "description": "Featuring best-in-class maneuverability and fully integrated, cutting-edge Xi’an tech, the next-generation Fury MX snub bomber from Mirai uses its twenty halo-mounted missiles to devastate targets during short-range space combat.",
     "dimensions": {
-      "w": 5.4,
-      "l": 7,
-      "h": 3
+      "width": 5.4,
+      "length": 7,
+      "height": 3
     },
     "hp": 6566,
     "hydrogenFuel": 2.75,
@@ -5908,9 +5908,9 @@
     "maxCrew": 1,
     "description": "Taking the adage that the best defense is a good offense, Mirai engineers have brought their expertise in performance and maneuverability to the Guardian long range fighter.  Fly circles around your opponents with the Mirai Guardian while establishing your space superiority. \\n",
     "dimensions": {
-      "w": 16.3,
-      "l": 24.3,
-      "h": 9.1
+      "width": 16.3,
+      "length": 24.3,
+      "height": 9.1
     },
     "hp": 69200,
     "hydrogenFuel": 9,
@@ -5965,9 +5965,9 @@
     "maxCrew": 1,
     "description": "Taking the framework of the Guardian fighter and adding even more offensive options, the Mirai Guardian MX packs additional firepower and armor ideal for overwhelming opponents. While not as nimble as the base Guardian, this heavy fighter is still more agile than many other ships in its class.\\n",
     "dimensions": {
-      "w": 17,
-      "l": 26,
-      "h": 10
+      "width": 17,
+      "length": 26,
+      "height": 10
     },
     "hp": 89300,
     "hydrogenFuel": 9,
@@ -6022,9 +6022,9 @@
     "maxCrew": 1,
     "description": "It’s not too surprising that hostiles may run when confronted with a powerful opponent, but thanks to its quantum dampening capabilities, the Mirai Guardian QI ensures that your enemies won’t be able to fight another day. Taking the best features of the base Guardian, the engineers at Mirai have made the QI variant the ideal complement to any protective forces.\\n",
     "dimensions": {
-      "w": 16.3,
-      "l": 24.3,
-      "h": 9.1
+      "width": 16.3,
+      "length": 24.3,
+      "height": 9.1
     },
     "hp": 69100,
     "hydrogenFuel": 9,
@@ -6086,9 +6086,9 @@
     "maxCrew": 1,
     "description": "Manufacturer: Mirai\\nFocus: Combat\\n \\nThe engineers at Mirai set out to craft an open-canopy bike capable of more. A more intimate connection between pilot and performance with a form-fitting silhouette. A more intuitive way to tame formidable landscapes with a responsive grav-lev system. A more intelligent combat experience with a custom weapon fully integrated into the spirit of the vehicle. The end result? The Mirai Pulse.\\n",
     "dimensions": {
-      "w": 1.5,
-      "l": 3.5,
-      "h": 2.5
+      "width": 1.5,
+      "length": 3.5,
+      "height": 2.5
     },
     "hp": 1150,
     "hydrogenFuel": 0.65,
@@ -6129,9 +6129,9 @@
     "maxCrew": 1,
     "description": "Manufacturer: Mirai\\nFocus: Racing\\n \\nSeamlessly pairing pilot and pure speed, the Mirai Pulse LX grav-lev bike soars over terrain like no open-canopy racer before. Feel your heartrate quicken as you experience first-hand the Pulse’s ground-breaking responsiveness and form-fitting silhouette.   \\n",
     "dimensions": {
-      "w": 1.5,
-      "l": 3.5,
-      "h": 2.5
+      "width": 1.5,
+      "length": 3.5,
+      "height": 2.5
     },
     "hp": 1150,
     "hydrogenFuel": 0.65,
@@ -6165,9 +6165,9 @@
     "maxCrew": 1,
     "description": "This advanced racer features an advanced composite spaceframe that puts pure speed ahead of everything else... it's the ship for pilots who want to leave the competition in the dust.",
     "dimensions": {
-      "w": 9,
-      "l": 12.5,
-      "h": 3
+      "width": 9,
+      "length": 12.5,
+      "height": 3
     },
     "hp": 8300,
     "hydrogenFuel": 3,
@@ -6222,9 +6222,9 @@
     "maxCrew": 1,
     "description": "Outfitted with signature-reducing materials, the Razor EX was a specialty build for the UEE Advocacy for use in surveillance and extraction operations. Although the EX was ultimately rejected for widespread use, a variation of the model was released for members of the public looking to keep a lower profile.",
     "dimensions": {
-      "w": 9,
-      "l": 12.5,
-      "h": 3
+      "width": 9,
+      "length": 12.5,
+      "height": 3
     },
     "hp": 8300,
     "hydrogenFuel": 3,
@@ -6279,9 +6279,9 @@
     "maxCrew": 1,
     "description": "The Razor gets supercharged. The LX features an overclocked engine to unleash blazing top speeds. This power comes at a cost with reduced maneuverability and armaments making it ideal for straight-shot racing. But who needs weapons when you’re leaving your competition in the dust.",
     "dimensions": {
-      "w": 9,
-      "l": 12.5,
-      "h": 3
+      "width": 9,
+      "length": 12.5,
+      "height": 3
     },
     "hp": 2900,
     "hydrogenFuel": 3,
@@ -6329,9 +6329,9 @@
     "maxCrew": 1,
     "description": "For those ready to elevate their profession to the next level, the engineers at MISC have carefully crafted the Fortune as a best-in-class small reclamation vessel. Equipped with a versatile salvage arm and a cargo lift, the MISC Fortune is built from the struts up to turn trash into treasure.\\n",
     "dimensions": {
-      "w": 16.5,
-      "l": 26.5,
-      "h": 8
+      "width": 16.5,
+      "length": 26.5,
+      "height": 8
     },
     "hp": 59500,
     "hydrogenFuel": 21,
@@ -6387,9 +6387,9 @@
     "maxCrew": 4,
     "description": "Freelancers are used as long haul merchant ships by major corporations, but they are just as frequently repurposed as dedicated exploration vessels by independent captains who want to operate on the fringes of the galaxy.",
     "dimensions": {
-      "w": 23.5,
-      "l": 38,
-      "h": 9.5
+      "width": 23.5,
+      "length": 38,
+      "height": 9.5
     },
     "hp": 31600,
     "hydrogenFuel": 108,
@@ -6449,9 +6449,9 @@
     "maxCrew": 4,
     "description": "The Freelancer DUR variant specializes in exploration. Sacrificing 25% cargo capacity of the standard Freelancer for an enhanced jump drive, a more advanced scanner, and an expanded fuel tank may seem like a bad call to some, but those who value discovery over profit will find it to be their ship of choice.",
     "dimensions": {
-      "w": 23.5,
-      "l": 38,
-      "h": 9.5
+      "width": 23.5,
+      "length": 38,
+      "height": 9.5
     },
     "hp": 22500,
     "hydrogenFuel": 140,
@@ -6511,9 +6511,9 @@
     "maxCrew": 4,
     "description": "Freelancer variant with additional cargo capacity at the expense of weapons. The Freelancer MAX variant sacrifices weaponry for an increased cargo capacity making it ideal for equipment or raw materials transport.",
     "dimensions": {
-      "w": 34,
-      "l": 38,
-      "h": 9.5
+      "width": 34,
+      "length": 38,
+      "height": 9.5
     },
     "hp": 21300,
     "hydrogenFuel": 58.5,
@@ -6573,9 +6573,9 @@
     "maxCrew": 4,
     "description": "The Freelancer MIS is a limited edition militarized variant of the classic mercantile ship developed by the UEE. These were produced in very small quantity due to some early payload incidents. This version sacrifices the majority of the cargo capacity to make way for missiles.",
     "dimensions": {
-      "w": 23.5,
-      "l": 38,
-      "h": 9.5
+      "width": 23.5,
+      "length": 38,
+      "height": 9.5
     },
     "hp": 21300,
     "hydrogenFuel": 58,
@@ -6634,9 +6634,9 @@
     "maxCrew": 1,
     "description": "The smallest, most affordable Hull. The Hull A is great for those just striking out in the galaxy on their own. The Hull A is most similar to the Aurora and Mustang, but lacks the ‘jack of all trades’ nature. Where the others trade cargo capacity for firepower or speed, the Hull A is 100% on-mission transport.",
     "dimensions": {
-      "w": 12.5,
-      "l": 30,
-      "h": 8
+      "width": 12.5,
+      "length": 30,
+      "height": 8
     },
     "hp": 130200,
     "hydrogenFuel": 16.4,
@@ -6685,9 +6685,9 @@
     "maxCrew": 4,
     "description": "Often called the most common ship in the galaxy, the Hull C is the most-produced of the range and is considered by many to be the most versatile. Intended to hit the ‘sweet spot’ between the smaller single-person transports and the massive superfreighters that make up the rest of the range, the Hull C offers the expansive modularity of the larger ships while still retaining a modicum of the maneuverability allowed the low end of the range.",
     "dimensions": {
-      "w": 36.05,
-      "l": 91.17,
-      "h": 26.28
+      "width": 36.05,
+      "length": 91.17,
+      "height": 26.28
     },
     "hp": 323500,
     "hydrogenFuel": 877,
@@ -6741,9 +6741,9 @@
     "maxCrew": 1,
     "description": "For years, the Prospector has been the universe’s preferred mining vessel for solo operators. Featuring MISC’s sleek design sensibility and a bevy of upgraded high-tech mining tools, the 2947 Prospector perfectly balances form and functionality.",
     "dimensions": {
-      "w": 16.5,
-      "l": 26.5,
-      "h": 8
+      "width": 16.5,
+      "length": 26.5,
+      "height": 8
     },
     "hp": 32600,
     "hydrogenFuel": 21,
@@ -6799,9 +6799,9 @@
     "maxCrew": 2,
     "description": "With the Reliant Kore, MISC adds to its already impressive lineup of ships, a smaller introductory-class spacecraft. Utilizing advanced Xi’An designs, the Reliant features broad, sleek wings, omni-directional thrusters and a fully-articulated two-seat cockpit that supports horizontal and vertical flight modes. All of this combines with a larger carrying capacity than many ships in its class to make the Kore a natural choice for short-range hauling, or with the simple addition of a few optional components, this can-do ship can do anything you dream of.",
     "dimensions": {
-      "w": 28.5,
-      "l": 14.75,
-      "h": 4.5
+      "width": 28.5,
+      "length": 14.75,
+      "height": 4.5
     },
     "hp": 15460,
     "hydrogenFuel": 10.5,
@@ -6863,9 +6863,9 @@
     "maxCrew": 2,
     "description": "The Empire depends on up-to-the-second information, which is why reporters need to be able to go where the news is happening: wherever, whenever. Enter the Mako, all the flexibility and dependability of a MISC Reliant combined with a state-of-the-art Cernan camera package to capture every moment as it happens with the clarity and accuracy that makes headlines.",
     "dimensions": {
-      "w": 28.5,
-      "l": 14.75,
-      "h": 4.5
+      "width": 28.5,
+      "length": 14.75,
+      "height": 4.5
     },
     "hp": 15460,
     "hydrogenFuel": 10.5,
@@ -6920,9 +6920,9 @@
     "maxCrew": 2,
     "description": "Magellan, Pierce, Croshaw, names that echo through history thanks to their adventurous spirit, a curious nature, and a reliable ship. The Reliant Sen is a versatile mobile science platform; outfitted with long range capabilities to take you further, longer, and the advanced Samos sensor suite. Perfect for the aspiring explorer who wants to whisper their name into the halls of history.",
     "dimensions": {
-      "w": 28.5,
-      "l": 14.75,
-      "h": 4.5
+      "width": 28.5,
+      "length": 14.75,
+      "height": 4.5
     },
     "hp": 15460,
     "hydrogenFuel": 10.5,
@@ -6977,9 +6977,9 @@
     "maxCrew": 2,
     "description": "With Humanity ever-expanding through the universe, the need for a versatile lightweight fighter has expanded with it. Easy to maintain with a rugged construction, the Reliant Tana makes for an ideal choice for frontier and outpost defense thanks to its custom high-yield power plant, stronger shields, and additional weapon mounts.",
     "dimensions": {
-      "w": 28.5,
-      "l": 14.75,
-      "h": 4.5
+      "width": 28.5,
+      "length": 14.75,
+      "height": 4.5
     },
     "hp": 14860,
     "hydrogenFuel": 7.5,
@@ -7039,9 +7039,9 @@
     "maxCrew": 8,
     "description": "The Starfarer differs from traditional bulk freighters in one key way: it is a dedicated fuel platform. The Starfarer is designed not only to load, store and protect fuel stasis units, it is designed to take in spaceborne gases and refine them for use without landing. And while it excels at this, the Starfarer can also be used to ferry traditional bulk cargo pods.",
     "dimensions": {
-      "w": 48.5,
-      "l": 102,
-      "h": 24.5
+      "width": 48.5,
+      "length": 102,
+      "height": 24.5
     },
     "hp": 75800,
     "hydrogenFuel": 652.2,
@@ -7089,9 +7089,9 @@
     "maxCrew": 6,
     "description": "The United Empire of Earth military uses an adapted ‘rough and tumble’ variant of the Starfarer for their front line operations. The G2M Gemini, more commonly the Starfarer Gemini or ‘Star G,’ trades some cargo capacity and maneuverability in exchange for reinforced armor, increased shielding, more powerful engines and stronger versions of the three manned turrets.",
     "dimensions": {
-      "w": 48.5,
-      "l": 102,
-      "h": 24.5
+      "width": 48.5,
+      "length": 102,
+      "height": 24.5
     },
     "hp": 77359.25,
     "hydrogenFuel": 652.2,
@@ -7146,9 +7146,9 @@
     "maxCrew": 4,
     "description": "Manufacturer: MISC\\nFocus: Cargo\\n \\nFor those looking to expand their hauling operations, the engineers at MISC have upgraded the Starlancer MAX with an extra spacious hold ready to transport cargo and vehicles. Paired with comfortable accommodations for longer trips and a full defensive package for when you go off the beaten path, it’s easy to see why the Starlancer MAX is the hauler of choice for industrious pilots across the ‘verse.",
     "dimensions": {
-      "w": 60,
-      "l": 90,
-      "h": 20
+      "width": 60,
+      "length": 90,
+      "height": 20
     },
     "hp": 84200,
     "hydrogenFuel": 50,
@@ -7202,9 +7202,9 @@
     "maxCrew": 1,
     "description": "Manufacturer: MISC\\nFocus: Combat\\n \\nFor those looking to for a versatile ship that can stand on its own in a fight, the engineers have upgraded the Starlancer TAC with an aggressive offensive package ready to face down the fiercest of foes. When you take on a high risk, high reward job, the Starlancer TAC is there to make sure you and your crew are able to see it through to the very end.",
     "dimensions": {
-      "w": 60,
-      "l": 90,
-      "h": 20
+      "width": 60,
+      "length": 90,
+      "height": 20
     },
     "hp": 116600,
     "hydrogenFuel": 48,
@@ -7259,9 +7259,9 @@
     "maxCrew": 1,
     "description": "Tour the universe with the perfect coupling of luxury and performance. The 100i features Origin Jumpworks' patented AIR fuel system, making it the most efficient and eco-friendly ship on the market. Capable of long distance flights that most ships of its size aren't equipped for, the 100i is perfect for solo pilots looking to turn heads without sacrificing functionality or reliability.",
     "dimensions": {
-      "w": 12,
-      "l": 19,
-      "h": 5
+      "width": 12,
+      "length": 19,
+      "height": 5
     },
     "hp": 3900,
     "hydrogenFuel": 6.5,
@@ -7316,9 +7316,9 @@
     "maxCrew": 1,
     "description": "Risks were meant to be taken, but why risk running out of fuel in the heat of battle? With the AIR fuel system, a souped-up weapons package, and all the luxury and refinement you've come to expect from Origin Jumpworks, the 125a has been designed for the discerning maverick.",
     "dimensions": {
-      "w": 12,
-      "l": 19,
-      "h": 5
+      "width": 12,
+      "length": 19,
+      "height": 5
     },
     "hp": 3900,
     "hydrogenFuel": 6.5,
@@ -7373,9 +7373,9 @@
     "maxCrew": 1,
     "description": "With a deceptive amount of storage space in its sleek, stylish frame, and Origin's patented AIR fuel system, the 135c model is the obvious choice for musicians, couriers, and anyone trying to get the party started. Get it there fast, and look good while you're doing it.",
     "dimensions": {
-      "w": 12,
-      "l": 19,
-      "h": 5
+      "width": 12,
+      "length": 19,
+      "height": 5
     },
     "hp": 3900,
     "hydrogenFuel": 6.5,
@@ -7430,9 +7430,9 @@
     "maxCrew": 1,
     "description": "If you're going to travel the stars... why not do it in style? The 300i is Origin Jumpworks' premiere luxury spacecraft. It is a sleek, silver killer that sends as much of a message with its silhouette as it does with its particle cannons.",
     "dimensions": {
-      "w": 17,
-      "l": 27,
-      "h": 8
+      "width": 17,
+      "length": 27,
+      "height": 8
     },
     "hp": 8200,
     "hydrogenFuel": 10.5,
@@ -7487,9 +7487,9 @@
     "maxCrew": 1,
     "description": "Exploration is man's highest calling. Prepare to chart distant horizons with man's most sophisticated piece of technology, the Origin 315p. Featuring a more robust power plant and a custom scanning package, exclusively designed by Chimera Communications.",
     "dimensions": {
-      "w": 17,
-      "l": 27,
-      "h": 8
+      "width": 17,
+      "length": 27,
+      "height": 8
     },
     "hp": 8200,
     "hydrogenFuel": 18,
@@ -7544,9 +7544,9 @@
     "maxCrew": 1,
     "description": "Just because it's a rough galaxy doesn't mean you need to sacrifice your comfort: the 325a can come out on top in any dogfight. The 325a features an advanced weapon payload as well as a custom targeting system designed especially for the 325a by WillsOp.",
     "dimensions": {
-      "w": 17,
-      "l": 27.5,
-      "h": 8
+      "width": 17,
+      "length": 27.5,
+      "height": 8
     },
     "hp": 8200,
     "hydrogenFuel": 18,
@@ -7611,9 +7611,9 @@
     "maxCrew": 1,
     "description": "Origin Jumpwork's 300 series is the ultimate fusion of elegance and astroengineering. Every component is individually calibrated to ensure your ship stays in perfect harmony. By far the fastest member of the family, the 350r refocus the 300's power and translates it into pure speed.",
     "dimensions": {
-      "w": 17,
-      "l": 27,
-      "h": 8
+      "width": 17,
+      "length": 27,
+      "height": 8
     },
     "hp": 3050,
     "hydrogenFuel": 27,
@@ -7669,9 +7669,9 @@
     "maxCrew": 3,
     "description": "To explore the stars is a most noble endeavor, and Origin Jumpworks has risen to the occasion in crafting the 400i high-performance pathfinder. With class-leading range, substantial defensive capabilities, and a factory-equipped scanning array, the 400i is ready to take on the harshest corners of the galaxy while maintaining the comfort and elegance Origin is known for.",
     "dimensions": {
-      "w": 32,
-      "l": 56,
-      "h": 12.5
+      "width": 32,
+      "length": 56,
+      "height": 12.5
     },
     "hp": 80500,
     "hydrogenFuel": 60,
@@ -7731,9 +7731,9 @@
     "maxCrew": 5,
     "description": "This multi-role luxury vessel from Origin Jumpworks features an exquisitely detailed hull design that balances performance and versatility in a sleek and timeless form. The 600i is designed with a cutting-edge modular technology, allowing you to customize your ship for your needs.",
     "dimensions": {
-      "w": 52,
-      "l": 91.5,
-      "h": 17
+      "width": 52,
+      "length": 91.5,
+      "height": 17
     },
     "hp": 192250,
     "hydrogenFuel": 180,
@@ -7788,9 +7788,9 @@
     "maxCrew": 5,
     "description": "This multi-role luxury vessel from Origin Jumpworks features an exquisitely detailed hull design that balances performance and versatility in a sleek and timeless form. The 600i is designed with a cutting-edge modular technology, allowing you to customize your ship for your needs.",
     "dimensions": {
-      "w": 52,
-      "l": 91.5,
-      "h": 17
+      "width": 52,
+      "length": 91.5,
+      "height": 17
     },
     "hp": 192250,
     "hydrogenFuel": 180,
@@ -7844,9 +7844,9 @@
     "maxCrew": 1,
     "description": "Elegantly styled and meticulously constructed, the 85X is a versatile and comprehensive away-vessel that features precision control in and out of atmosphere. Utilizing much of the same thruster technology as the 300 series, it has the power of a racer with the reliability of a touring ship. Whether descending down to the planet surface or taking in the sights of your system, this runabout continues Origin’s proud tradition of turning heads.",
     "dimensions": {
-      "w": 14,
-      "l": 13.5,
-      "h": 4
+      "width": 14,
+      "length": 13.5,
+      "height": 4
     },
     "hp": 2800,
     "hydrogenFuel": 4.5,
@@ -7895,9 +7895,9 @@
     "maxCrew": 8,
     "description": "With an elegant, sleek exterior that belies its spacious interior, the 890 Jump is a true engineering marvel; crafted to impress from every angle by combining a unique, innovative design with the finest materials and the most advanced technology. The result is a vessel that is in a class all of its own, a masterpiece worthy of the name Origin.",
     "dimensions": {
-      "w": 80,
-      "l": 210,
-      "h": 45
+      "width": 80,
+      "length": 210,
+      "height": 45
     },
     "hp": 153200,
     "hydrogenFuel": 1200,
@@ -7944,9 +7944,9 @@
     "maxCrew": 1,
     "description": "If you want to get from point A to point B as quickly as possible and with as much style as possible then Origin's M50 is for you. Featuring supercharged engines that counter a tiny weapons loadout, the M50 is a ship for going FAST.",
     "dimensions": {
-      "w": 11,
-      "l": 11.5,
-      "h": 3.5
+      "width": 11,
+      "length": 11.5,
+      "height": 3.5
     },
     "hp": 3621,
     "hydrogenFuel": 3,
@@ -8001,9 +8001,9 @@
     "maxCrew": 1,
     "description": "Welcome to the next level with the X1, Origin Jumpworks' high performance open-canopy vehicle. Built from lightweight polymers, the X1 takes speed and agility to the next level thanks to seamlessly integrated engine technology and joint vector thruster placement. Innovative design and high-quality engineering weave together to create a flight experience like no other.",
     "dimensions": {
-      "w": 5.19,
-      "l": 1.55,
-      "h": 1.87
+      "width": 5.19,
+      "length": 1.55,
+      "height": 1.87
     },
     "hp": 2820,
     "hydrogenFuel": 0.9,
@@ -8044,9 +8044,9 @@
     "maxCrew": 1,
     "description": "Built to endure tougher environments and look good doing it, the X1 Force is a modified version of the base X1 model featuring additional defensive elements to toughen up this speedy and agile open-canopy bike, allowing it to serve in a variety of roles, from exploring worlds to potential security infiltration ops.",
     "dimensions": {
-      "w": 5.19,
-      "l": 1.55,
-      "h": 1.87
+      "width": 5.19,
+      "length": 1.55,
+      "height": 1.87
     },
     "hp": 2820,
     "hydrogenFuel": 0.9,
@@ -8094,9 +8094,9 @@
     "maxCrew": 1,
     "description": "How do you make fast go faster? Origin Jumpworks' X1 Velocity dares to push the boundaries of speed by stripping down the base X1 to its core elements; eliminating the weapon mount and incorporating new Syntek composites to create a lighter chassis for overall weight loss.",
     "dimensions": {
-      "w": 5.19,
-      "l": 1.55,
-      "h": 1.87
+      "width": 5.19,
+      "length": 1.55,
+      "height": 1.87
     },
     "hp": 2820,
     "hydrogenFuel": 0.9,
@@ -8131,9 +8131,9 @@
     "maxCrew": 2,
     "description": "A life-saving ship with enhanced armor and missile racks, capable of responding to calls in the heaviest combat. A product of RSI’s proven history in critical aid, the Medivac provides robust, adaptable medical support under fire, keeping crews alive in the most dangerous situations.",
     "dimensions": {
-      "w": 54,
-      "l": 73,
-      "h": 14
+      "width": 54,
+      "length": 73,
+      "height": 14
     },
     "hp": 121700,
     "hydrogenFuel": 63,
@@ -8195,9 +8195,9 @@
     "maxCrew": 2,
     "description": "A life-saving ship for rapid response and emergency medical assistance. A product of RSI’s proven history in critical aid, the Triage delivers highly configurable, professional-level medical care anywhere in the galaxy.",
     "dimensions": {
-      "w": 54,
-      "l": 73,
-      "h": 14
+      "width": 54,
+      "length": 73,
+      "height": 14
     },
     "hp": 121700,
     "hydrogenFuel": 63,
@@ -8258,9 +8258,9 @@
     "maxCrew": 1,
     "description": "Customized for mercantile and trading excursions, the Aurora Clipper is the perfect vessel for aspiring entrepreneurs and seasoned traders alike. Swapping a smaller power plant and armor capabilities for an expanded cargo capacity, the Clipper ups the ante for personal merchant craft.",
     "dimensions": {
-      "w": 8.75,
-      "l": 19,
-      "h": 4.5
+      "width": 8.75,
+      "length": 19,
+      "height": 4.5
     },
     "hp": 5740,
     "hydrogenFuel": 4.5,
@@ -8315,9 +8315,9 @@
     "maxCrew": 1,
     "description": "The Aurora is the modern day descendant of the Roberts Space Industries X-7 spacecraft which tested the very first jump engines. Utilitarian to a T, the Aurora is the perfect beginner's ship: what it lacks in style it makes up for in ample room for upgrade modules.",
     "dimensions": {
-      "w": 8.75,
-      "l": 19,
-      "h": 4.5
+      "width": 8.75,
+      "length": 19,
+      "height": 4.5
     },
     "hp": 5740,
     "hydrogenFuel": 4.5,
@@ -8372,9 +8372,9 @@
     "maxCrew": 1,
     "description": "With a more robust shield generator and a pair of additional weapon hard points, the Legionnaire is a dedicated combat fighter, built to handle any obstacle the universe can throw at you.",
     "dimensions": {
-      "w": 8.75,
-      "l": 19,
-      "h": 4.5
+      "width": 8.75,
+      "length": 19,
+      "height": 4.5
     },
     "hp": 5740,
     "hydrogenFuel": 4.5,
@@ -8429,9 +8429,9 @@
     "maxCrew": 1,
     "description": "Be proud of your roots with the brand-new Aurora Deluxe, built for the discerning pilot who never forgets where he or she came from. The LX features patent leather interior to guarantee comfort for those long stretches in the deep black.",
     "dimensions": {
-      "w": 8.75,
-      "l": 19,
-      "h": 4.5
+      "width": 8.75,
+      "length": 19,
+      "height": 4.5
     },
     "hp": 5740,
     "hydrogenFuel": 4.5,
@@ -8486,9 +8486,9 @@
     "maxCrew": 1,
     "description": "Perhaps you're looking for something that offers carrying capacity but has combat capabilities too? The Aurora Marque comes with a pair of Behring-quality lasers and a high quality gun cooler system.",
     "dimensions": {
-      "w": 8.75,
-      "l": 19,
-      "h": 4.5
+      "width": 8.75,
+      "length": 19,
+      "height": 4.5
     },
     "hp": 5740,
     "hydrogenFuel": 4.5,
@@ -8544,9 +8544,9 @@
     "maxCrew": 4,
     "description": "The Constellation Andromeda is a dependable multi-crew freighter that appeals to merchants across the empire thanks to its versatility. One of the most popular ships that RSI produces, the iconic Andromeda features a well-appointed cargo bay, a snub-fighter docking port, and a signature wrap-around bridge.",
     "dimensions": {
-      "w": 27.75,
-      "l": 63.5,
-      "h": 15.25
+      "width": 27.75,
+      "length": 63.5,
+      "height": 15.25
     },
     "hp": 180644,
     "hydrogenFuel": 66,
@@ -8606,9 +8606,9 @@
     "maxCrew": 4,
     "description": "Designed by RSI to traverse distant frontiers, the Constellation Aquila features a redesigned cockpit for maximum visibility, advanced sensors, and a P-52 snub craft and Ursa rover for planetary exploration. Discover for yourself why explorers the ‘verse over choose to captain the Aquila.",
     "dimensions": {
-      "w": 27.75,
-      "l": 63.5,
-      "h": 15.25
+      "width": 27.75,
+      "length": 63.5,
+      "height": 15.25
     },
     "hp": 180644,
     "hydrogenFuel": 104.5,
@@ -8663,9 +8663,9 @@
     "maxCrew": 4,
     "description": "A dedicated luxury spacecraft for the discerning star captain. The Constellation Phoenix can be operated as an organization command ship and features a luxurious redesigned interior. Includes a hidden sensor-dampened area for your most precious cargo. The Phoenix comes with a Lynx rover and a Kruger P-72 Archimedes Fighter.",
     "dimensions": {
-      "w": 27.75,
-      "l": 63.5,
-      "h": 15.25
+      "width": 27.75,
+      "length": 63.5,
+      "height": 15.25
     },
     "hp": 161145,
     "hydrogenFuel": 66,
@@ -8720,9 +8720,9 @@
     "maxCrew": 4,
     "description": "Paired down to fully focus on hauling, the Taurus provides the most cargo space of any ship in RSI’s Constellation line-up. What it loses in versatility it more than makes up for in potential profits thanks to its tractor beams, a cargo release system for quick unloading, and a security hold reinforced with tech plating.",
     "dimensions": {
-      "w": 27.75,
-      "l": 70,
-      "h": 15.25
+      "width": 27.75,
+      "length": 70,
+      "height": 15.25
     },
     "hp": 130040,
     "hydrogenFuel": 66,
@@ -8783,9 +8783,9 @@
     "maxCrew": 1,
     "description": "Stop ships dead in their tracks with RSI’s premier Quantum Enforcement ship. The Mantis features a tailor-made Quantum Enforcement Device from Wei-Tek, capable of ripping ships out of QT with its Quantum Snare and preventing hasty escapes with its Quantum Dampener.",
     "dimensions": {
-      "w": 17,
-      "l": 30,
-      "h": 7.5
+      "width": 17,
+      "length": 30,
+      "height": 7.5
     },
     "hp": 32476,
     "hydrogenFuel": 31.6125,
@@ -8847,9 +8847,9 @@
     "maxCrew": 1,
     "description": "Packing some serious firepower, the Meteor is a sight enemies won't want to see. Taking inspiration from the iconic Mantis, this heavy fighter forgoes quantum enforcement and instead features two bespoke S5 ballistic cannons and four single-load S4 missile racks; making the Meteor a force that can light up the sky like a shooting star.",
     "dimensions": {
-      "w": 17,
-      "l": 30,
-      "h": 7.5
+      "width": 17,
+      "length": 30,
+      "height": 7.5
     },
     "hp": 30150,
     "hydrogenFuel": 28.95,
@@ -8915,9 +8915,9 @@
     "maxCrew": 12,
     "description": "The Polaris is a nimble corvette-class capital ship that packs a powerful punch with a full armament of turrets and torpedoes. Intended for use as both a naval patrol ship and to serve as the flagship of militia operations, Polaris has the capacity to perform search and rescue operations, light strike missions and general security patrols. The Polaris includes the facilities to repair, rearm and refuel a single fighter, light bomber or support ship.",
     "dimensions": {
-      "w": 87,
-      "l": 181,
-      "h": 40
+      "width": 87,
+      "length": 181,
+      "height": 40
     },
     "hp": 3947100,
     "hydrogenFuel": 1100,
@@ -8964,9 +8964,9 @@
     "maxCrew": 2,
     "description": "With an adaptable bi-wing configuration and revolutionary rail-mounted remote turret, the Scorpius offers unprecedented fire coverage, allowing for both defensive and assault-minded applications.",
     "dimensions": {
-      "w": 24,
-      "l": 32,
-      "h": 13
+      "width": 24,
+      "length": 32,
+      "height": 13
     },
     "hp": 43660,
     "hydrogenFuel": 13.5,
@@ -9021,9 +9021,9 @@
     "maxCrew": 2,
     "description": "RSI has updated the signature Scorpius adaptable bi-wing configuration and added a bespoke Quantum Dampener and EMP Device exclusively designed by their in-house team to create the powerful Scorpius Antares. Built with stopping power in mind, the Scorpius Antares is engineered to bring any chase to a quick finish.",
     "dimensions": {
-      "w": 24,
-      "l": 32,
-      "h": 13
+      "width": 24,
+      "length": 32,
+      "height": 13
     },
     "hp": 43660,
     "hydrogenFuel": 13.5,
@@ -9091,9 +9091,9 @@
     "maxCrew": 3,
     "description": "Ready to ferry a whole new generation of travelers across the universe, Roberts Space Industries is proud to introduce a starship eight centuries in the making - the all-new Zeus Mk II spacecraft. Paying homage to the classic design that launched Humanity to the stars in 2140, the Zeus Mk II has been updated to exceed modern standards while retaining the heart of this beloved spacefaring icon.  With a focus on commerce, the Zeus Mk II CL edition features additional cargo space and a tractor beam ideal for handling large volumes of cargo.",
     "dimensions": {
-      "w": 35,
-      "l": 46,
-      "h": 9
+      "width": 35,
+      "length": 46,
+      "height": 9
     },
     "hp": 32000,
     "hydrogenFuel": 66.5,
@@ -9155,9 +9155,9 @@
     "maxCrew": 3,
     "description": "Ready to ferry a whole new generation of travelers across the universe, Roberts Space Industries is proud to introduce a starship eight centuries in the making - the all-new Zeus Mk II spacecraft. Paying homage to the classic design that launched Humanity to the stars in 2140, the Zeus Mk II has been updated to exceed modern standards while retaining the heart of this beloved spacefaring icon.  With a focus on exploration, the Zeus Mk II ES edition features a robust radar package for finding new discoveries, and enhanced weaponry and shielding to help bring them back home.\\n",
     "dimensions": {
-      "w": 35,
-      "l": 46,
-      "h": 9
+      "width": 35,
+      "length": 46,
+      "height": 9
     },
     "hp": 32000,
     "hydrogenFuel": 93.1,
@@ -9211,9 +9211,9 @@
     "maxCrew": 1,
     "description": "Fast becoming the symbol of the Vanduul Race, the Scythe is the foot soldier in every raid and the target of every human fighter pilot. Featuring a hefty weapons payload, the Scythe's real asset is its maneuverability, found in the twin main and twelve maneuvering thrusters. This captured Vanduul-made Scythe has been modified by Esperia to be flyable by Human pilots.",
     "dimensions": {
-      "w": 24,
-      "l": 33,
-      "h": 9
+      "width": 24,
+      "length": 33,
+      "height": 9
     },
     "hp": 11701,
     "hydrogenFuel": 22,
@@ -9273,9 +9273,9 @@
     "maxCrew": 2,
     "description": "Keep your airspace clear of danger with the Anvil Ballista. Originally designed to defend outposts from Vanduul attacks, this mobile missile defense system packs a powerful loadout, allowing the Ballista to stand firm against any threat, whether it arrives by air or land.",
     "dimensions": {
-      "w": 7,
-      "l": 17,
-      "h": 5.5
+      "width": 7,
+      "length": 17,
+      "height": 5.5
     },
     "hp": 24200,
     "hydrogenFuel": null,
@@ -9315,9 +9315,9 @@
     "maxCrew": 2,
     "description": "Built on Anvil's popular Atlas Platform, the Centurion presents a tactical solution for short-range anti-aircraft operations. Thanks to the Centurion’s custom energy-based AA turret, your forces can establish ground superiority by assuring immediate threats from above are dealt with quickly and efficiently.",
     "dimensions": {
-      "w": 7,
-      "l": 17,
-      "h": 5.5
+      "width": 7,
+      "length": 17,
+      "height": 5.5
     },
     "hp": 20000,
     "hydrogenFuel": null,
@@ -9357,9 +9357,9 @@
     "maxCrew": 1,
     "description": "Built on Anvil’s robust Atlas Platform, the same chassis used for their devastating Ballista air defense system, the Spartan is a fully armored transport outfitted with eight jump seats. The Spartan’s rugged frame makes it perfect for all kinds of terrain, and its remote Gatling turret helps clear the area for easier deployment.",
     "dimensions": {
-      "w": 7,
-      "l": 17,
-      "h": 5.5
+      "width": 7,
+      "length": 17,
+      "height": 5.5
     },
     "hp": 24201,
     "hydrogenFuel": null,
@@ -9399,9 +9399,9 @@
     "maxCrew": 1,
     "description": "You got your plot of land, you’ve got the right construction materials, and now you’re ready to watch your dreams take shape. The ideal companion to the CSV-FM, the CSV Supply Model provides additional storage for all the resources required to build your next settlement.\\n",
     "dimensions": {
-      "w": 8.75,
-      "l": 6,
-      "h": 3.5
+      "width": 8.75,
+      "length": 6,
+      "height": 3.5
     },
     "hp": 8100,
     "hydrogenFuel": null,
@@ -9434,9 +9434,9 @@
     "maxCrew": 1,
     "description": "The six-wheeled Drake Mule is a dependable workhorse for all sorts of loading and hauling jobs. Whether transporting cargo over rough terrain or ferrying it onto larger vessels and cargo decks, the Mule sees even the toughest contracts through to the end. Plain and simple.",
     "dimensions": {
-      "w": 8.75,
-      "l": 6,
-      "h": 3.5
+      "width": 8.75,
+      "length": 6,
+      "height": 3.5
     },
     "hp": 5800,
     "hydrogenFuel": null,
@@ -9462,9 +9462,9 @@
     "maxCrew": 1,
     "description": "As an expert in industrial operations, Greycat understands that jobsite security is a vital part of any successful business venture. Not only that, but to be fully effective, you need to be able to get your security personnel and their equipment to wherever they’re needed most. That’s why the MTC Mobile Tactical Center is such an important addition to your next venture. Nimble enough to access the difficult terrain encountered at remote operations and equipped with enough suit lockers, weapon racks, and storage to tackle a wide host of issues, the Greycat MTC could make all the difference when it comes to turning a potential problem into potential profit.",
     "dimensions": {
-      "w": 8.75,
-      "l": 6,
-      "h": 5
+      "width": 8.75,
+      "length": 6,
+      "height": 5
     },
     "hp": 16990,
     "hydrogenFuel": 23.625,
@@ -9504,9 +9504,9 @@
     "maxCrew": 1,
     "description": "The Greycat PTV is a simple and practical buggy frequently used to reduce long walk distance in large hangers or outpost.",
     "dimensions": {
-      "w": 2.5,
-      "l": 3.5,
-      "h": 2.2
+      "width": 2.5,
+      "length": 3.5,
+      "height": 2.2
     },
     "hp": 8510,
     "hydrogenFuel": 1,
@@ -9532,9 +9532,9 @@
     "maxCrew": 1,
     "description": "By focusing on the essentials of terrestrial-based mining, Greycat Industrial designed their hardworking, no-nonsense ROC (Remote Ore Collector) to complement the miners who use it. From its precision gimbaled mining arm to its all-terrain wheels, this solo-operated vehicle shows how important it is to have the right tool for the job.",
     "dimensions": {
-      "w": 3.9,
-      "l": 6,
-      "h": 3.5
+      "width": 3.9,
+      "length": 6,
+      "height": 3.5
     },
     "hp": 3400,
     "hydrogenFuel": null,
@@ -9567,9 +9567,9 @@
     "maxCrew": 2,
     "description": "By focusing on the essentials of terrestrial-based mining, Greycat Industrial designed their hardworking, no-nonsense ROC-DS (Remote Ore Collector Dual Seat) to let mining pairs do more while in the field. The ROC-DS raises the ground-mining game by adding extra cargo capacity and a second seat to operate the precision gimbaled mining arm. Greycat even upgraded the driver's cab with a protective enclosure to allow for longer excursions in harsh conditions. With the ROC-DS, mining duos now have the right tool to comfortably collect more ore.",
     "dimensions": {
-      "w": 5,
-      "l": 6.6,
-      "h": 3.5
+      "width": 5,
+      "length": 6.6,
+      "height": 3.5
     },
     "hp": 4900,
     "hydrogenFuel": null,
@@ -9602,9 +9602,9 @@
     "maxCrew": 2,
     "description": "Get ready to have some serious fun on the job with the STV from Greycat. This Sport Terrain Vehicle was built by pros for pros and features blazing speed and convenient built-in storage.",
     "dimensions": {
-      "w": 8.75,
-      "l": 6,
-      "h": 3.5
+      "width": 8.75,
+      "length": 6,
+      "height": 3.5
     },
     "hp": 4250,
     "hydrogenFuel": null,
@@ -9630,9 +9630,9 @@
     "maxCrew": 2,
     "description": "RSI designed the Lynx Rover to be a vehicle capable of exploring a wide variety of terrains while still delivering a top-rated and finely tuned driving experience.",
     "dimensions": {
-      "w": 5.7,
-      "l": 7.75,
-      "h": 3.5
+      "width": 5.7,
+      "length": 7.75,
+      "height": 3.5
     },
     "hp": 22700,
     "hydrogenFuel": null,
@@ -9673,9 +9673,9 @@
     "maxCrew": 2,
     "description": "Built by RSI specifically for the planetside explorer, the Ursa Rover offers civilians military-grade all-terrain capabilities and stands as the rugged standard in ground-based scouting, mapping and discovery applications.",
     "dimensions": {
-      "w": 8.75,
-      "l": 6,
-      "h": 3.5
+      "width": 8.75,
+      "length": 6,
+      "height": 3.5
     },
     "hp": 25200,
     "hydrogenFuel": null,
@@ -9715,9 +9715,9 @@
     "maxCrew": 2,
     "description": "Manufacturer: RSI\\nFocus: Medical\\n \\nEven in the most remote of planetside destinations, there are people who could use a helping hand. Designed by RSI to cross even the most rugged terrain, the Ursa Medivac features a Tier 3 Medical Bed ideal for offering aid wherever its needed most.",
     "dimensions": {
-      "w": 8.75,
-      "l": 6,
-      "h": 3.5
+      "width": 8.75,
+      "length": 6,
+      "height": 3.5
     },
     "hp": 26700,
     "hydrogenFuel": null,
@@ -9764,9 +9764,9 @@
     "maxCrew": 2,
     "description": "With a potent combination of speed, maneuverability, and rugged durability, the Cyclone is a perfect choice for local deliveries and transport between planetside homesteads and outposts.",
     "dimensions": {
-      "w": 8.75,
-      "l": 6,
-      "h": 3.5
+      "width": 8.75,
+      "length": 6,
+      "height": 3.5
     },
     "hp": 6910,
     "hydrogenFuel": null,
@@ -9799,9 +9799,9 @@
     "maxCrew": 2,
     "description": "A battlefield equalizer, the Cyclone AA comes equipped with a surface-to-air missile and countermeasure package to provide cover for ground troops against airborne targets.",
     "dimensions": {
-      "w": 8.75,
-      "l": 6,
-      "h": 3.5
+      "width": 8.75,
+      "length": 6,
+      "height": 3.5
     },
     "hp": 6910,
     "hydrogenFuel": null,
@@ -9848,9 +9848,9 @@
     "maxCrew": 3,
     "description": "Following the success of the initial release of the Cyclone, Tumbril has taken your feedback and expanded their popular line of tactical vehicles with the all new Cyclone MT. Outfitted with a combination gun and missile turret, this module offers increased combat options in the field.",
     "dimensions": {
-      "w": 8.75,
-      "l": 6,
-      "h": 3.5
+      "width": 8.75,
+      "length": 6,
+      "height": 3.5
     },
     "hp": 6910,
     "hydrogenFuel": null,
@@ -9882,9 +9882,9 @@
     "maxCrew": 1,
     "description": "For those who like to push the limits of speed, the Cyclone RC features a modified intake system to allow for controlled bursts of speed as well as tools to customize handling.",
     "dimensions": {
-      "w": 8.75,
-      "l": 6,
-      "h": 3.5
+      "width": 8.75,
+      "length": 6,
+      "height": 3.5
     },
     "hp": 6910,
     "hydrogenFuel": null,
@@ -9917,9 +9917,9 @@
     "maxCrew": 1,
     "description": "Stay mobile and aware with the Cyclone RN. This light reconnaissance vehicle is the perfect solution for scouting runs, providing fast and detailed scans of terrain as well as beacon placement.",
     "dimensions": {
-      "w": 8.75,
-      "l": 6,
-      "h": 3.5
+      "width": 8.75,
+      "length": 6,
+      "height": 3.5
     },
     "hp": 6910,
     "hydrogenFuel": null,
@@ -9953,9 +9953,9 @@
     "maxCrew": 3,
     "description": "Designed for militia and security use, the Cyclone TR module features upgraded armor and a single Human-operated turret capable of mounting a Size 1 weapon and a responsive 360° field of fire.",
     "dimensions": {
-      "w": 8.75,
-      "l": 6,
-      "h": 3.5
+      "width": 8.75,
+      "length": 6,
+      "height": 3.5
     },
     "hp": 6910,
     "hydrogenFuel": null,
@@ -9988,9 +9988,9 @@
     "maxCrew": 2,
     "description": "Tumbril's new Nova is a classic battlefield warrior, reimagined for the modern age. This heavy tank offers a devastating combination of weaponry to eliminate threats on the ground and in the air.",
     "dimensions": {
-      "w": 12,
-      "l": 20,
-      "h": 11
+      "width": 12,
+      "length": 20,
+      "height": 11
     },
     "hp": 110000,
     "hydrogenFuel": null,
@@ -10036,9 +10036,9 @@
     "maxCrew": 1,
     "description": "Manufacturer: Tumbril Land Systems\\nFocus: Combat\\n \\nOriginally introduced in 2606 during the Second Tevarin War, the Tumbril Storm single-operator mini-tank was built to blitz battlefields and take out enemy artillery. Reimagined from the ground up to be faster, stronger, and more impactful than ever, the latest Storm is a true force of nature, well-suited to the frenetic landscape of modern warfare.",
     "dimensions": {
-      "w": 10.25,
-      "l": 7.65,
-      "h": 4
+      "width": 10.25,
+      "length": 7.65,
+      "height": 4
     },
     "hp": 89000,
     "hydrogenFuel": 5,
@@ -10078,9 +10078,9 @@
     "maxCrew": 1,
     "description": "Originally introduced in 2606 during the Second Tevarin War, the Tumbril Storm single-operator mini-tank was built to blitz battlefields and take out enemy artillery. Reimagined from the ground up to be faster, stronger, and more impactful than ever, the Storm AA is a true force of nature, equipped with a barrage of missiles to provide cover against airborne and ground targets.",
     "dimensions": {
-      "w": 10.25,
-      "l": 7.65,
-      "h": 4
+      "width": 10.25,
+      "length": 7.65,
+      "height": 4
     },
     "hp": 89000,
     "hydrogenFuel": 5,

--- a/src/schemas/ship.schemas.ts
+++ b/src/schemas/ship.schemas.ts
@@ -28,9 +28,9 @@ export const ManufacturerSchema = z.object({
 
 // Dimensions Schema
 export const DimensionsSchema = z.object({
-  w: z.number().positive(),
-  l: z.number().positive(),
-  h: z.number().positive()
+  width: z.number().positive(),
+  length: z.number().positive(),
+  height: z.number().positive()
 });
 
 // Hardpoint Schema


### PR DESCRIPTION
## Description

Updated the data model to use longhand names for dimensions.  
Changed `w`, `h`, and `l` → `width`, `height`, and `length` for improved clarity and consistency with other schema naming conventions.  

This includes updating schemas, TypeScript types, and transforming existing data to match the new format.

## Related Issues

- Closes #23 

## Changes Made

- Renamed schema fields:
  - `w` → `width`
  - `h` → `height`
  - `l` → `length`
- Updated JSON data and validation schemas accordingly  

## How to Test

1. Pull this branch  
2. Run `npm install` (if any deps were updated)  
3. Start the project  
4. Create or update entities with dimensions — confirm that new records use `width`, `height`, `length` instead of shorthand.  
5. Check existing records have been migrated to the new field names.  

## Checklist

- [x] Updated schemas and types  
- [x] Data migration applied successfully    
- [x] Code style and linting pass  
